### PR TITLE
Set customdatatype when saving issue field options

### DIFF
--- a/core/classes/TBGCustomDatatype.class.php
+++ b/core/classes/TBGCustomDatatype.class.php
@@ -180,6 +180,7 @@
 			$option->setKey($this->getKey());
 			$option->setValue($value);
 			$option->setItemdata($itemdata);
+			$option->setCustomdatatype($this->_id);
 			$option->save();
 			$this->_options = null;
 			return $option;

--- a/core/classes/TBGCustomDatatypeOption.class.php
+++ b/core/classes/TBGCustomDatatypeOption.class.php
@@ -109,4 +109,20 @@
 			$this->_value = $value;
 		}
 
+		/**
+		 * @param int $customdatatype
+		 */
+		public function setCustomdatatype($customdatatype)
+		{
+			$this->_customdatatype = $customdatatype;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getCustomdatatype()
+		{
+			return $this->_customdatatype;
+		}
+
 	}


### PR DESCRIPTION
Previously this wasn't being set, so the issue field options could not be loaded.
