### PR TITLE
Set Description when adding a new custom field

### DIFF
--- a/modules/configuration/classes/actions.class.php
+++ b/modules/configuration/classes/actions.class.php
@@ -706,6 +706,7 @@
 							$customtype = new TBGCustomDatatype();
 							$customtype->setName($request['name']);
 							$customtype->setItemdata($request['label']);
+							$customtype->setDescription($request['label']);
 							$customtype->setType($request['field_type']);
 							$customtype->save();
 							return $this->renderJSON(array('title' => TBGContext::getI18n()->__('The custom field was added'), 'content' => $this->getComponentHTML('issuefields_customtype', array('type_key' => $customtype->getKey(), 'type' => $customtype))));


### PR DESCRIPTION
Previously the label of a custom field was not saving correctly when creating a new field.
