### PR TITLE
Fix conflicting ID's causing issues editing/deleting issue options

### DIFF
--- a/modules/configuration/templates/_issuefield.inc.php
+++ b/modules/configuration/templates/_issuefield.inc.php
@@ -1,4 +1,4 @@
-<tr class="hover_highlight" id="item_<?php echo $type; ?>_<?php echo $item->getID(); ?>">
+<tr class="hover_highlight" id="item_option_<?php echo $type; ?>_<?php echo $item->getID(); ?>">
 	<?php if ($type == 'status'): ?>
 		<td style="width: 30px;"><div style="border: 0; background-color: <?php echo $item->getColor(); ?>; font-size: 1px; width: 25px; height: 8px; margin-right: 2px;" id="<?php echo $type; ?>_<?php echo $item->getID(); ?>_itemdata">&nbsp;</div></td>
 	<?php endif; ?>
@@ -7,17 +7,17 @@
 	<?php endif; ?>
 	<td style="padding: 2px; font-size: 12px;" id="<?php echo $type; ?>_<?php echo $item->getID(); ?>_name"><?php echo $item->getName(); ?></td>
 	<td style="width: 60px; padding: 2px; text-align: right;">
-		<a href="javascript:void(0);" onclick="$('item_<?php echo $type; ?>_<?php echo $item->getID(); ?>').hide();$('edit_item_<?php echo $item->getID(); ?>').show();$('<?php echo $type; ?>_<?php echo $item->getID(); ?>_name_input').focus();" class="image" title="<?php echo __('Edit this item'); ?>"><?php echo image_tag('icon_edit.png'); ?></a>
-		<a href="javascript:void(0);" onclick="$('item_<?php echo $item->getID(); ?>_permissions').toggle();" class="image" title="<?php echo __('Set permissions for this item'); ?>" style="margin-right: 5px;"><?php echo image_tag('cfg_icon_permissions.png'); ?></a>
+		<a href="javascript:void(0);" onclick="$('item_option_<?php echo $type; ?>_<?php echo $item->getID(); ?>').hide();$('edit_item_option_<?php echo $item->getID(); ?>').show();$('<?php echo $type; ?>_<?php echo $item->getID(); ?>_name_input').focus();" class="image" title="<?php echo __('Edit this item'); ?>"><?php echo image_tag('icon_edit.png'); ?></a>
+		<a href="javascript:void(0);" onclick="$('item_option_<?php echo $item->getID(); ?>_permissions').toggle();" class="image" title="<?php echo __('Set permissions for this item'); ?>" style="margin-right: 5px;"><?php echo image_tag('cfg_icon_permissions.png'); ?></a>
 		<?php if ($item->canBeDeleted()): ?>
-			<a href="javascript:void(0);" onclick="$('delete_item_<?php echo $item->getID(); ?>').toggle();" class="image" id="delete_<?php echo $item->getID(); ?>_link"><?php echo image_tag('icon_delete.png'); ?></a>
+			<a href="javascript:void(0);" onclick="$('delete_item_option_<?php echo $item->getID(); ?>').toggle();" class="image" id="delete_<?php echo $item->getID(); ?>_link"><?php echo image_tag('icon_delete.png'); ?></a>
 		<?php else: ?>
 			<a href="javascript:void(0);" onclick="TBG.Main.Helpers.Message.error('<?php echo __('This item cannot be deleted'); ?>', '<?php echo __('Other items - such as workflow steps - may depend on this item to exist. Remove the dependant item or unlink it from this item to continue.'); ?>');" class="image" id="delete_<?php echo $item->getID(); ?>_link"><?php echo image_tag('icon_delete_disabled.png'); ?></a>
 		<?php endif; ?>
 		<?php echo image_tag('spinning_16.gif', array('id' => 'delete_' . $type . '_' . $item->getID() . '_indicator', 'style' => 'display: none;')); ?>
 	</td>
 </tr>
-<tr id="edit_item_<?php echo $item->getID(); ?>" style="display: none;">
+<tr id="edit_item_option_<?php echo $item->getID(); ?>" style="display: none;">
 	<td colspan="3">
 		<form accept-charset="<?php echo TBGContext::getI18n()->getCharset(); ?>" action="<?php echo make_url('configure_issuefields_edit', array('type' => $type, 'id' => $item->getID())); ?>" onsubmit="TBG.Config.Issuefields.Options.update('<?php echo make_url('configure_issuefields_edit', array('type' => $type, 'id' => $item->getID())); ?>', '<?php echo $type; ?>', <?php echo $item->getID(); ?>);return false;" id="edit_<?php echo $type; ?>_<?php echo $item->getID(); ?>_form">
 			<table style="width: 100%;" cellpadding="0" cellspacing="0">
@@ -38,14 +38,14 @@
 					<td style="text-align: right; width: 150px;">
 						<?php echo image_tag('spinning_16.gif', array('style' => 'margin-right: 5px; display: none;', 'id' => 'edit_' . $type . '_' . $item->getID() . '_indicator')); ?>
 						<input type="submit" value="<?php echo __('Update'); ?>" style="margin-right: 5px; font-weight: bold;">
-						<?php echo __('%update% or %cancel%', array('%update%' => '', '%cancel%' => '<a href="javascript:void(0);" onclick="$(\'item_'.$type.'_'.$item->getID().'\').show();$(\'edit_item_'.$item->getID().'\').hide();"><b>' . __('cancel') . '</b></a>')); ?>
+						<?php echo __('%update% or %cancel%', array('%update%' => '', '%cancel%' => '<a href="javascript:void(0);" onclick="$(\'item_option_'.$type.'_'.$item->getID().'\').show();$(\'edit_item_option_'.$item->getID().'\').hide();"><b>' . __('cancel') . '</b></a>')); ?>
 					</td>
 				</tr>
 			</table>
 		</form>
 	</td>
 </tr>
-<tr id="delete_item_<?php echo $item->getID(); ?>" style="display: none;">
+<tr id="delete_item_option_<?php echo $item->getID(); ?>" style="display: none;">
 	<td colspan="3">
 		<div class="rounded_box white shadowed" style="margin: 5px 0 10px 0; font-size: 12px;">
 				<div class="header"><?php echo __('Really delete "%itemname%"?', array('%itemname%' => $item->getName())); ?></div>
@@ -53,14 +53,14 @@
 					<?php echo __('Are you really sure you want to delete this item?'); ?>
 					<div style="text-align: right; font-size: 13px;">
 						<a href="javascript:void(0);" onclick="TBG.Config.Issuefields.Options.remove('<?php echo make_url('configure_issuefields_delete', array('type' => $type, 'id' => $item->getID())); ?>', '<?php echo $type; ?>', <?php echo $item->getID(); ?>);"><?php echo __('Yes'); ?></a> ::
-						<a href="javascript:void(0);" onclick="$('delete_item_<?php echo $item->getID(); ?>').toggle();"><b><?php echo __('No'); ?></b></a>
+						<a href="javascript:void(0);" onclick="$('delete_item_option_<?php echo $item->getID(); ?>').toggle();"><b><?php echo __('No'); ?></b></a>
 					</div>
 				</div>
 			</div>
 		</div>
 	</td>
 </tr>
-<tr id="item_<?php echo $item->getID(); ?>_permissions" style="display: none;">
+<tr id="item_option_<?php echo $item->getID(); ?>_permissions" style="display: none;">
 	<td colspan="3">
 		<div class="rounded_box white" style="margin: 5px 0 10px 0; padding: 3px; font-size: 12px;">
 			<div class="header"><?php echo __('Permission details for "%itemname%"', array('%itemname%' => $item->getName())); ?></div>

--- a/thebuggenie/js/thebuggenie.js
+++ b/thebuggenie/js/thebuggenie.js
@@ -2078,8 +2078,8 @@ TBG.Config.Issuefields.Options.update = function(url, type, id) {
 		form: 'edit_' + type + '_' + id + '_form',
 		loading: {indicator: 'edit_' + type + '_' + id + '_indicator'},
 		success: {
-			show: 'item_' + type + '_' + id,
-			hide: 'edit_item_' + id,
+			show: 'item_option_' + type + '_' + id,
+			hide: 'edit_item_option_' + id,
 			callback: function(json) {
 				$(type + '_' + id + '_name').update($(type + '_' + id + '_name_input').getValue());
 				if ($(type + '_' + id + '_itemdata_input') && $(type + '_' + id + '_itemdata')) $(type + '_' + id + '_itemdata').style.backgroundColor = $(type + '_' + id + '_itemdata_input').getValue();
@@ -2093,7 +2093,7 @@ TBG.Config.Issuefields.Options.remove = function(url, type, id) {
 	TBG.Main.Helpers.ajax(url, {
 		loading: {indicator: 'delete_' + type + '_' + id + '_indicator'},
 		success: {
-			remove: ['delete_item_' + id, 'item_' + type + '_' + id]
+			remove: ['delete_item_option_' + id, 'item_option_' + type + '_' + id]
 		}
 	});
 }


### PR DESCRIPTION
Issue field option td ID's occasionally collided with the ID's of the issue field box ID's, causing incorrect elements to be hidden or incorrect placement of confirmation messages. Changed issue field option ID's to include 'option' to make them unique.
