### PR TITLE
Fix ability to save options on built-in issue fields

### DIFF
--- a/modules/configuration/classes/actions.class.php
+++ b/modules/configuration/classes/actions.class.php
@@ -707,7 +707,7 @@
 							$customtype = TBGCustomDatatype::getByKey($request['type']);
 							$item = TBGContext::factory()->TBGCustomDatatypeOption($request['id']);
 						}
-						if ($item instanceof TBGDatatypeBase && $item->getItemtype() == $item->getType())
+						if ($item instanceof TBGDatatypeBase)
 						{
 							$item->setName($request['name']);
 							$item->setItemdata($request['itemdata']);


### PR DESCRIPTION
Want to run this fix by you before committing. Currently on next you're unable to save changes to options on the built-in issue fields (ex. change the color of a status) because of a fatal error (`Call to undefined method TBGStatus::getType()`).

Removing the condition that calls this method fixes the issue, and it seems like the condition isn't needed, but I'm not sure what the intention was behind it. getItemType() returns the _itemtype property, and the two places where getType() exist also return the same _itemtype property. 
