### PR TITLE
Next

### DIFF
--- a/thebuggenie/index.php
+++ b/thebuggenie/index.php
@@ -10,6 +10,7 @@
 	defined('THEBUGGENIE_PUBLIC_FOLDER_NAME') || define('THEBUGGENIE_PUBLIC_FOLDER_NAME', mb_substr($path, strrpos($path, DS) + 1));
 	defined('B2DB_BASEPATH') || define ('B2DB_BASEPATH', THEBUGGENIE_CORE_PATH . 'B2DB' . DS);
 	defined('B2DB_CACHEPATH') || define ('B2DB_CACHEPATH', THEBUGGENIE_CORE_PATH . 'cache' . DS . 'B2DB' . DS);
+	defined('GESHI_ROOT') || define('GESHI_ROOT', THEBUGGENIE_CORE_PATH . 'geshi' . DS);
 	
 	// Include the "engine" script, which initializes and sets up stuff
 	require THEBUGGENIE_CORE_PATH . 'bootstrap.php';


### PR DESCRIPTION
This is a fix for bug #1349 which I have opened.
Define GESHI_ROOT in index.php - the define statement seems to have been lost somewhere along the way.

Currently the GESHI_ROOT define is in ui.inc.php in the geshi_highlight method. But this method is not used anywhere other than in debug.html.php 

The code highlighting is actually dome from TBGTextParser.class.php when rendering the wiki.
