### PR TITLE
Patch 1

### DIFF
--- a/modules/mailing/classes/TBGMailing.class.php
+++ b/modules/mailing/classes/TBGMailing.class.php
@@ -974,9 +974,9 @@
 			{
 				$name = $email;
 
-				if (($q_pos = strpos($email, "<")) !== false)
+				if (($q_pos = strpos($email_string, "<")) !== false)
 				{
-					$name = trim(substr($email, 0, $q_pos - 1));
+					$name = trim(substr($email_string, 0, $q_pos - 1));
 				}
 
 				$user = new TBGUser();


### PR DESCRIPTION
Buddyname was always the same as $email. It should use $email_string instead which has name and email.
