### PR TITLE
Fix 'redirect login' check for when guest access is disabled

### DIFF
--- a/core/classes/TBGContext.class.php
+++ b/core/classes/TBGContext.class.php
@@ -2411,7 +2411,7 @@
 					{
 						$route = array('module' => 'installation', 'action' => 'installIntro');
 					}
-					if (self::$_redirect_login && !self::getRouting()->getCurrentRouteName('debug'))
+					if (self::$_redirect_login)
 					{
 						TBGLogging::log('An error occurred setting up the user object, redirecting to login', 'main', TBGLogging::LEVEL_NOTICE);
 						TBGContext::setMessage('login_message_err', TBGContext::geti18n()->__('Please log in'));


### PR DESCRIPTION
If anonymous access was disabled, hitting pages like issue detail was not redirecting to login.
Removed route check causing login redirect check to fail, not sure why that check was necessary with debug parameter.
