### PR TITLE
Patch 4

### DIFF
--- a/modules/mailing/classes/TBGIncomingEmailAccount.class.php
+++ b/modules/mailing/classes/TBGIncomingEmailAccount.class.php
@@ -257,7 +257,7 @@
 		{
 			if ($this->_connection === null)
 			{
-				$this->_connection = imap_open($this->getConnectionString(), $this->getUsername(), $this->getPassword(), OP_READONLY);
+				$this->_connection = imap_open($this->getConnectionString(), $this->getUsername(), $this->getPassword());
 			}
 			if (!is_resource($this->_connection))
 			{


### PR DESCRIPTION
Removed OP_READONLY from imap open. Emails are now marked as read after downloading it
