### PR TITLE
Fix problems with custom fields that link to other TBG objects

### DIFF
--- a/core/classes/TBGCustomDatatype.class.php
+++ b/core/classes/TBGCustomDatatype.class.php
@@ -137,9 +137,16 @@
 			return null;
 		}
 
-		public static function getChoiceFieldsAsArray()
+		public static function getCustomChoiceFieldsAsArray()
 		{
 			return array(self::CHECKBOX_CHOICES, self::DROPDOWN_CHOICE_TEXT, self::RADIO_CHOICE);
+		}
+
+		public static function getChoiceFieldsAsArray()
+		{
+			return array(self::CHECKBOX_CHOICES, self::DROPDOWN_CHOICE_TEXT, self::RADIO_CHOICE, self::RELEASES_CHOICE,
+			             self::COMPONENTS_CHOICE, self::EDITIONS_CHOICE, self::STATUS_CHOICE, self::USER_CHOICE,
+			             self::TEAM_CHOICE, self::USER_OR_TEAM_CHOICE);
 		}
 
 		/**
@@ -215,6 +222,11 @@
 		}
 
 		public function hasCustomOptions()
+		{
+			return (bool) in_array($this->getType(), self::getCustomChoiceFieldsAsArray());
+		}
+
+		public function hasPredefinedOptions()
 		{
 			return (bool) in_array($this->getType(), self::getChoiceFieldsAsArray());
 		}

--- a/core/classes/TBGIssue.class.php
+++ b/core/classes/TBGIssue.class.php
@@ -853,6 +853,10 @@
 							$this->$var_name = $option;
 						}
 					}
+					else if($datatype->hasPredefinedOptions())
+					{
+						$this->$var_name = $row->get(TBGIssueCustomFieldsTable::CUSTOMFIELDOPTION_ID);
+					}
 					else
 					{
 						$this->$var_name = $row->get(TBGIssueCustomFieldsTable::OPTION_VALUE);


### PR DESCRIPTION
- Fixes change log comments for RELEASES_CHOICE fields
- Fix some fields in json output for issues (custom fields with custom choices still don't work correctly, custom fields that select other TBG objects (e.g. releases) only output the target id)
- Fixes TBGIssue::_initializeCustomfields for fields that select other TBG objects

For the last one I fixed it so that the custom field member is initialized to the target id as this is expected by other code using and changing these fields - it incorrectly used the (always empty) custom value before. However using the linked objects (e.g. TBGBuild) might be more consistent with the way custom fields with a user-defined list of choices are handled.
