### PR TITLE
Fix links to specific comments

### DIFF
--- a/modules/main/templates/_comment.inc.php
+++ b/modules/main/templates/_comment.inc.php
@@ -2,7 +2,7 @@
 <div class="comment<?php if ($comment->isSystemComment()): ?> system_comment<?php endif; ?>" id="comment_<?php echo $comment->getID(); ?>"<?php if ($comment->isSystemComment()): ?> style="display: none;"<?php endif; ?>>
 	<div style="position: relative; overflow: visible; padding: 5px;" id="comment_view_<?php echo $comment->getID(); ?>" class="comment_main">
 		<div id="comment_<?php echo $comment->getID(); ?>_header" class="commentheader">
-			<a href="#comment_<?php echo $comment->getTargetType(); ?>_<?php echo $comment->getTargetID(); ?>_<?php echo $comment->getID(); ?>" class="comment_hash">#<?php echo $comment->getCommentNumber(); ?></a>
+			<a href="#comment_<?php echo $comment->getID(); ?>" class="comment_hash">#<?php echo $comment->getCommentNumber(); ?></a>
 			<?php if (($comment->canUserEditComment() || $comment->canUserDeleteComment()) && ((TBGContext::isProjectContext() && !TBGContext::getCurrentProject()->isArchived()) || !TBGContext::isProjectContext())) : ?>
 				<div class="commenttools button-group">
 					<?php if ($comment->canUserEditComment()): ?><a href="javascript:void(0)" class="button button-silver" onclick="$('comment_view_<?php echo $comment->getID(); ?>').hide();$('comment_edit_<?php echo $comment->getID(); ?>').show();"><?php echo image_tag('icon_edit.png', array('title' => __('Edit'))); ?><?php echo __('Edit'); ?></a><?php endif; ?>


### PR DESCRIPTION
The links to comments included the issue type and id as well as the
comment id  in the hash part, but the comment div's id only includes
the comment id.

```
Old link: #comment_<issue-type>_<issue-id>_<comment-id>
New link: #comment_<comment-id>
```
