### PR TITLE
PHP 5.4 changed the return array of ob_get_status so that it no longe…

### DIFF
--- a/core/classes/TBGResponse.class.php
+++ b/core/classes/TBGResponse.class.php
@@ -161,7 +161,7 @@
 		public function cleanBuffer()
 		{
 			$ob_status = ob_get_status();
-			if (!empty($ob_status) && $ob_status['status'] != PHP_OUTPUT_HANDLER_END)
+			if (!empty($ob_status) && ((isset($ob_status['status'])&& $ob_status['status'] != PHP_OUTPUT_HANDLER_END)|| (isset($ob_status['flags'])&&!($ob_status['flags'] & PHP_OUTPUT_HANDLER_END))))
 			{
 				ob_end_clean();
 			}


### PR DESCRIPTION
…r includes ['status'] but instead includes ['flags'] which is a bit map of flags.

See: https://bugs.php.net/bug.php?id=62019
