### PR TITLE
added space between label and checkbox, fixed position of checkbox relat...

### DIFF
--- a/thebuggenie/themes/oxygen/oxygen.css
+++ b/thebuggenie/themes/oxygen/oxygen.css
@@ -53,9 +53,10 @@ th { font-weight: bold; border-bottom: 1px solid #DDD; padding: 2px; background-
 
 dt { float: left; width: 420px; }
 dt label { padding-left: 0; }
+dd { margin-left: 0px; margin-bottom: 15px; vertical-align: middle; }
 label { font-weight: bold; margin: 0px; padding: 2px; cursor: pointer; }
 label .faded_out { font-weight: normal; }
-dd { margin-left: 0px; margin-bottom: 15px; vertical-align: middle; }
+label > input[type="checkbox"] { margin: 0 3px; position: relative; top: 2px;}
 
 div.image_container { border: 1px solid #CCC; padding: 3px; background-color: #F3F3F3; width: auto; margin: 0 5px 0 5px; float: right; clear: right; }
 div.image_container icleft { float: left; clear: left; }


### PR DESCRIPTION
Added space between label and checkbox, fixed position of checkbox relative to the label.
This was wrong if a checkbox is in a label <label><input type="checkbox" ..></label>.
For example: Issue Detail > Comments > "Show system-generated comments[ ]". The checkbox is to close to the words an a bit to high.

Added CSS-Rule applies only to checkboxes in labels.
