### PR TITLE
turn on browser's HTTP cache for static contents

### DIFF
--- a/modules/main/classes/actions.class.php
+++ b/modules/main/classes/actions.class.php
@@ -3683,6 +3683,12 @@
 		
 		public function runServe(TBGRequest $request)
 		{
+			
+			// turn on browser's HTTP cache for static contents
+			header("Cache-Control: ");
+			header("Pragma: public");
+			header("Expires: Sat, 26 Jul ".(date('Y')+1)." 05:00:00 GMT");
+
 			if(!TBGContext::isMinifyEnabled())
 			{
 				$itemarray = array($request['g'] => explode(',', base64_decode($request['files'])));


### PR DESCRIPTION
Final fix for caching of served static contents. 
Submitted second time. 
If not accepted, please explain why - it is a polite manner for one contributing to your project.
