### PR TITLE
Added folder(aka labels) option to incoming email

### DIFF
--- a/i18n/en_US/strings.inc.php
+++ b/i18n/en_US/strings.inc.php
@@ -1699,6 +1699,7 @@
   $strings['Server name:'] = 'Server name:';
   $strings['Enter the name of the incoming email server'] = 'Enter the name of the incoming email server';
   $strings['Port number:'] = 'Port number:';
+  $strings['Email folder name:'] = 'Folder Name:';
   $strings['Email username:'] = 'Email username:';
   $strings['Email password:'] = 'Email password:';
   $strings['Account type'] = 'Account type';

--- a/modules/mailing/classes/B2DB/TBGIncomingEmailAccountTable.class.php
+++ b/modules/mailing/classes/B2DB/TBGIncomingEmailAccountTable.class.php
@@ -19,6 +19,7 @@
 		const PASSWORD = 'mailing_incoming_email_account.password';
 		const SERVER = 'mailing_incoming_email_account.server';
 		const PORT = 'mailing_incoming_email_account.port';
+		const FOLDER = 'mailing_incoming_email_account.folder';
 		const SERVER_TYPE = 'mailing_incoming_email_account.server_type';
 		const SSL = 'mailing_incoming_email_account.ssl';
 		const KEEP_EMAIL = 'mailing_incoming_email_account.keep_email';

--- a/modules/mailing/classes/TBGIncomingEmailAccount.class.php
+++ b/modules/mailing/classes/TBGIncomingEmailAccount.class.php
@@ -25,6 +25,11 @@
 		protected $_port;
 		
 		/**
+		 * @Column(type="string", length=200)
+		 */
+		protected $_folder;
+		
+		/**
 		 * @Column(type="integer", length=10)
 		 */
 		protected $_server_type;
@@ -132,6 +137,16 @@
 		public function setServer($server)
 		{
 			$this->_server = $server;
+		}
+		
+		public function getFoldername()
+		{
+			return $this->_folder;
+		}
+		
+		public function setFoldername($folder)
+		{
+			$this->_Foldername = $folder;
 		}
 
 		public function getPort()
@@ -246,7 +261,10 @@
 			
 			if ($this->usesSSL()) $conn_string .= "/ssl";
 			
-			$conn_string .= "}INBOX";
+			$conn_string .= "}";
+			
+			$conn_string .= ($this->getFoldername() == '') ? "INBOX" : $this->getFoldername();
+			
 			
 			return $conn_string;
 		}
@@ -258,7 +276,7 @@
 		{
 			if ($this->_connection === null)
 			{
-				$this->_connection = imap_open($this->getConnectionString(), $this->getUsername(), $this->getPassword());
+				$this->_connection = imap_open($this->getConnectionString(), $this->getUsername(), $this->getPassword());				
 			}
 			if (!is_resource($this->_connection))
 			{

--- a/modules/mailing/templates/_editincomingemailaccount.inc.php
+++ b/modules/mailing/templates/_editincomingemailaccount.inc.php
@@ -43,6 +43,10 @@
 					<td><label for="account_port"><?php echo __('Port number:'); ?></label></td>
 					<td><input type="text" name="port" id="account_port" style="width: 50px;" value="<?php echo $account->getPort(); ?>"></td>
 				</tr>
+                <tr>
+					<td><label for="account_foldername"><?php echo __('Email folder name:'); ?></label></td>
+					<td><input type="text" name="folder" id="account_foldername" style="width: 200px;" value="<?php echo $account->getFoldername(); ?>"></td>
+				</tr>
 				<tr>
 					<td><label for="account_username"><?php echo __('Email username:'); ?></label></td>
 					<td><input type="text" name="username" id="account_username" style="width: 200px;" value="<?php echo $account->getUsername(); ?>"></td>


### PR DESCRIPTION
Option to set folder name in the incoming email settings. That way same account can be used for different projects and different issue types. Gmail names folders as labels. It has been tested with gmail and a regular account using imap and it works just fine.

I had to add one field to the incoming email module table: "folder".

CREATE TABLE `tbg3_mailing_incoming_email_account` (
  `name` varchar(200) DEFAULT NULL,
  `server` varchar(200) DEFAULT NULL,
  `port` int(10) DEFAULT '0',
  `server_type` int(10) DEFAULT '0',
  `ssl` tinyint(1) DEFAULT NULL,
  `keep_email` tinyint(1) DEFAULT NULL,
  `username` varchar(200) DEFAULT NULL,
  `password` varchar(200) DEFAULT NULL,
  `project` int(10) DEFAULT '0',
  `issuetype` int(10) DEFAULT '0',
  `num_last_fetched` int(10) DEFAULT '0',
  `time_last_fetched` int(10) DEFAULT '0',
  `scope` int(10) DEFAULT '0',
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `folder` varchar(200) DEFAULT NULL,
  PRIMARY KEY (`id`)
) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
