### PR TITLE
Keep Email option to incoming email

### DIFF
--- a/i18n/en_US/strings.inc.php
+++ b/i18n/en_US/strings.inc.php
@@ -1701,6 +1701,8 @@
   $strings['Port number:'] = 'Port number:';
   $strings['Email folder name:'] = 'Folder Name:';
   $strings['Enter folder name to read from. Leave blank for default (INBOX)'] = 'Enter folder name to read from. Leave blank for default (INBOX)';
+  $strings['Keep email:'] = 'Keep email:';
+  $strings['Select whether emails should be kept or removed from the account after being downloaded'] = 'Select whether emails should be kept or removed from the account after being downloaded';
   $strings['Email username:'] = 'Email username:';
   $strings['Email password:'] = 'Email password:';
   $strings['Account type'] = 'Account type';

--- a/modules/mailing/classes/TBGIncomingEmailAccount.class.php
+++ b/modules/mailing/classes/TBGIncomingEmailAccount.class.php
@@ -287,10 +287,14 @@
 		}
 		
 		/**
-		 * Disconnects this account from the imap resource
+		 * Disconnects this account from the imap resource		 * 
 		 */
 		public function disconnect()
 		{
+			if(!$this->doesKeepEmails())
+			{
+			    imap_expunge($this->connection);
+			}
 			imap_close($this->_connection);
 			$this->_connection = null;
 		}
@@ -327,6 +331,7 @@
 		/**
 		 * Takes an email object and looks up details for this particular email
 		 * Returns the primary body and the mime type
+		 * Sets the message for deletion when chosen to do not keep emails 
 		 * 
 		 * @param stdObject $email
 		 * @return TBGIncomingEmailMessage the message
@@ -334,7 +339,11 @@
 		public function getMessage($email)
 		{
 			$message = new TBGIncomingEmailMessage($this->_connection, $email->msgno);
-			$message->fetch();
+			$is_structure = $message->fetch();
+			if($is_structure && !$this->doesKeepEmails())
+			{
+			    imap_delete($this->_connection, $email->msgno);
+			}
 			return $message;
 		}
 		

--- a/modules/mailing/classes/actions.class.php
+++ b/modules/mailing/classes/actions.class.php
@@ -109,6 +109,7 @@
 					$account->setPort((integer) $request['port']);
 					$account->setName($request['name']);
 					$account->setFoldername($request['folder']);
+					$account->setKeepEmails($request['keepemail']);
 					$account->setServer($request['servername']);
 					$account->setUsername($request['username']);
 					$account->setPassword($request['password']);

--- a/modules/mailing/templates/_editincomingemailaccount.inc.php
+++ b/modules/mailing/templates/_editincomingemailaccount.inc.php
@@ -52,6 +52,17 @@
 					<td class="faded_out"><?php echo __('Enter folder name to read from. Leave blank for default (INBOX)'); ?></td>
 				</tr>
 				<tr>
+					<td><label for="keepemail"><?php echo __('Keep email:'); ?></label></td>
+					<td>
+					    <input type="radio" name="keepemail" id="account_keepemail_yes" value="1"<?php if ($account->doesKeepEmails()) echo ' checked'; ?>><label for="account_keepemail_yes" style="font-weight: normal;"><?php echo __('Yes'); ?></label>
+					    <input type="radio" name="keepemail" id="account_keepemail_no" value="0"<?php if (!$account->doesKeepEmails()) echo ' checked'; ?>><label for="account_keepemail_no" style="font-weight: normal;"><?php echo __('No'); ?></label>
+					</td>
+				</tr>
+				<tr>
+					<td>&nbsp;</td>
+					<td class="faded_out"><?php echo __('Select whether emails should be kept or removed from the account after being downloaded'); ?></td>
+				</tr>
+				<tr>
 					<td><label for="account_username"><?php echo __('Email username:'); ?></label></td>
 					<td><input type="text" name="username" id="account_username" style="width: 200px;" value="<?php echo $account->getUsername(); ?>"></td>
 				</tr>


### PR DESCRIPTION
Added Keep Email option to incoming email. It uses the already created table field 'keep_email'. Tested successfully with imap. Messages are marked for deletion when read and expunged when connection is closed.
