### PR TITLE
Notification when comments are created through incoming email

### DIFF
--- a/modules/mailing/classes/TBGMailing.class.php
+++ b/modules/mailing/classes/TBGMailing.class.php
@@ -1155,15 +1155,17 @@
 							if ($issue instanceof TBGIssue)
 							{
 								$text = preg_replace('#(^\w.+:\n)?(^>.*(\n|$))+#mi', "", $data);
-								$text = trim($text);
+								$text = trim($text);								
 								if (!$this->processIncomingEmailCommand($text, $issue, $user) && $user->canPostComments())
 								{
 									$comment = new TBGComment();
+									$comment->setTitle('Untitled comment');
 									$comment->setContent($text);
 									$comment->setPostedBy($user);
 									$comment->setTargetID($issue->getID());
 									$comment->setTargetType(TBGComment::TYPE_ISSUE);
 									$comment->save();
+									TBGEvent::createNew('core', 'TBGComment::createNew', $issue, array('comment' => $comment))->trigger();								
 								}
 							}
 							else


### PR DESCRIPTION
This is more a question than a pull request. I'm using github to do this because it makes easier to explain what I'm trying to achieve.

Right now users in verbose mode are only notified about a comment added into a issue when the comment is manually created. This behavior happens because you create an event on _postsave in the TBGIssue class. 

When the mailing class detects a new comment through an email it doesn't have any event. Comments are added to the issue but because there's no event there are no listeners to catch that event. 

Here's what I did: I created an event when comments are added through incoming email. That way users are now notified when comments are added. I also had to add a title to the comment, otherwise the listener would fail because there was no name set. I'm just not sure if this would be the right solution for the problem. Help?!
