### PR TITLE
Fix Undefined Key When Deleting Custom Issue Field

### DIFF
--- a/core/classes/TBGCustomDatatype.class.php
+++ b/core/classes/TBGCustomDatatype.class.php
@@ -112,7 +112,7 @@
 		protected function _preDelete()
 		{
 			TBGCustomFieldOptionsTable::getTable()->deleteCustomFieldOptions($this->getID());
-			\b2db\Core::getTable('TBGIssueFieldsTable')->deleteByIssueFieldKey($key);
+			\b2db\Core::getTable('TBGIssueFieldsTable')->deleteByIssueFieldKey($this->getKey());
 		}
 
 		public static function doesKeyExist($key)


### PR DESCRIPTION
Attempting to delete a custom issue field results in an error "Undefined variable: key"
