### PR TITLE
Fix Overflow For Numerous Choices Dropdown

### DIFF
--- a/thebuggenie/themes/oxygen/oxygen.css
+++ b/thebuggenie/themes/oxygen/oxygen.css
@@ -1037,6 +1037,7 @@ dd { float: left; display: block; width: 195px; font-weight: normal; margin: 0; 
 .dropdown_content ul li { font-size: 1em; font-weight: normal; margin: 0; text-align: left; min-height: 18px; padding: 1px; }
 .dropdown_content table, .dropdown_content table td { font-weight: normal; margin: 0; text-align: left; height: 18px; padding: 1px; }
 .dropdown_content table { margin-top: 5px; }
+.dropdown_content > ul.choices { max-height: 250px; overflow-y: auto; }
 /* end dropdown */
 /* end left hand list */
 


### PR DESCRIPTION
If you have a large number of milestones ( or issue field choices ), it is possible that the drop down will scroll off the issue reporting screen, preventing you from selecting choices towards the bottom of the list.  This commit sets a maximum size for the drop downs and enables overflow scrolling when necessary.
