### PR TITLE
Prevent Open ID buttons from jumping below.

### DIFF
--- a/modules/main/templates/_login.inc.php
+++ b/modules/main/templates/_login.inc.php
@@ -25,7 +25,7 @@
 						<?php else: ?>
 							<input type="hidden" id="return_to" name="return_to" value="<?php echo $referer; ?>" />
 						<?php endif; ?>
-						<div style="width:300px;" class="login_boxheader"><?php echo __('Log in to an existing account'); ?></div>
+						<div class="login_boxheader regular"><?php echo __('Log in to an existing account'); ?></div>
 						<div>
 							<table border="0" class="login_fieldtable">
 								<tr>

--- a/thebuggenie/themes/oxygen/oxygen.css
+++ b/thebuggenie/themes/oxygen/oxygen.css
@@ -191,6 +191,7 @@ footer td { font-size: 0.9em; line-height: 1.2; padding: 5px; text-shadow: 1px 1
 .logindiv.openid_container { width: 600px; float: right; }
 .logindiv.openid_container form { width: 590px; }
 .login_boxheader { font-size: 1.4em; font-weight: bold; padding-bottom: 10px; }
+.login_boxheader.regular { width:300px; }
 .login_fieldheader { font-weight: bold; }
 .login_fieldtable { margin-left: auto; margin-right: auto; }
 .logindiv input[type='password'] { font-family: sans-serif; } /* IE does not like web fonts on password boxes, and turns it into blankness, so we will use a different font */


### PR DESCRIPTION
See issue #1386 for more details.

Open ID buttons jump below the "Continue" button because login title and text inputs are too large when using French translation for example.
