### PR TITLE
When registering using openId the email is not saved and sending email w...

### DIFF
--- a/modules/mailing/classes/TBGMailing.class.php
+++ b/modules/mailing/classes/TBGMailing.class.php
@@ -220,7 +220,9 @@
 				$password = TBGUser::createPassword(8);
 				$user->setPassword($password);
 				$user->save();
-				if ($this->isOutgoingNotificationsEnabled())
+                
+                $email_address = $user->getEmail();
+				if ($this->isOutgoingNotificationsEnabled() && !empty($email_address))
 				{
 					$subject = TBGContext::getI18n()->__('User account registered with The Bug Genie');
 					$message = $this->createNewTBGMimemailFromTemplate($subject, 'registeruser', array('user' => $user, 'password' => $password), null, array(array('name' => $user->getBuddyname(), 'address' => $user->getEmail())));


### PR DESCRIPTION
...ill throw a error.

You should not attempt to send emails to a user with no email address or at least skip it and show a notification (not breaking the register process)

Original find: https://github.com/kenneththorman
