### PR TITLE
Enable Git VCS post-commit hook to run on Windows hosts

### DIFF
--- a/core/classes/TBGContext.class.php
+++ b/core/classes/TBGContext.class.php
@@ -2569,8 +2569,22 @@
 
 		public static function getCurrentCLIusername()
 		{
-			$processUser = posix_getpwuid(posix_geteuid());
-			return $processUser['name'];
+			if(extension_loaded('posix'))
+			{
+				// Original code
+				$processUser = posix_getpwuid(posix_geteuid());
+					return $processUser['name'];
+			}
+			else
+			{
+				// Try to get CLI process owner without the POSIX extension
+				$environmentUser = getenv('USERNAME');
+				if($environmentUser === false)
+				{
+					$environmentUser = 'Unknown';
+				}
+				return $environmentUser;
+			}
 		}
 
 		public static function isDebugMode()


### PR DESCRIPTION
Removed the posix dependency that prevented the Git VCS hook (and potentially others, only tested with Git) from being used on Windows hosts.
Original modification by "Lucas" in the article http://www.flyingtophat.co.uk/blog/26/git-integration-with-the-bug-genie-on-windows.
