### PR TITLE
Fix transition key to work for prefixed projects as well. 

### DIFF
--- a/modules/vcs_integration/classes/TBGVCSIntegration.class.php
+++ b/modules/vcs_integration/classes/TBGVCSIntegration.class.php
@@ -616,7 +616,7 @@
 				$inst->setIssue($issue);
 				$inst->setCommit($commit);
 				$inst->save();
-				foreach ($transitions[$issue->getIssueNo()] as $issue_transition_block)
+				foreach ($transitions[$issue->getFormattedIssueNo()] as $issue_transition_block)
 				{
 					preg_match('/(?<=\()(.*)(?=\))/', $issue_transition_block, $issue_transitions, null);
 					


### PR DESCRIPTION
A small fix that will allow transitions to work properly. Seeing that throughout the related code everything uses getFormattedIssueNo() method, this one was probably an oversight.
