### PR TITLE
Removed erroneous array wrapper around the issue regular expressions.

### DIFF
--- a/core/classes/TBGTextParser.class.php
+++ b/core/classes/TBGTextParser.class.php
@@ -118,10 +118,10 @@
 				// (#)ISSUE_NUMBER (TRANSITIONS)" (parenthesis means optional). For
 				// example:
 				// "Resolves issue #2 (Resolve issue)"
-				$regex[] = array('#( |^)(?<!\!)(('.$issue_string.')\s\#?(?P<issues>([A-Z0-9]+\-)?\d+))(?P<transitions> \(.*?\))?#i');
+				$regex[] = '#( |^)(?<!\!)(('.$issue_string.')\s\#?(?P<issues>([A-Z0-9]+\-)?\d+))(?P<transitions> \(.*?\))?#i';
 				// This regex will match messages that contain template at the beginning
 				// of message in format "ISSUE_NUMBER: (TRANSITIONS)".
-				$regex[] = array('#^(?<!\!)((?P<issues>([A-Z0-9]+\-)?\d+)):(?P<transitions> \(.*?\))?#i');
+				$regex[] = '#^(?<!\!)((?P<issues>([A-Z0-9]+\-)?\d+)):(?P<transitions> \(.*?\))?#i';
 
 				// Add the constructed regexes to cache.
 				TBGCache::add(TBGCache::KEY_TEXTPARSER_ISSUE_REGEX, $regex);


### PR DESCRIPTION
My commit for issue 1995 was actually broken. I had an extra array() around the regular expressions. This small change will fix that.

There's a couple of more places that I didn't pay attention to where getIssueRegex() is used, so I'll have to take care of those (in separate pull request).
