### PR TITLE
Reduce excessive pulsing of save changed dialog

### DIFF
--- a/thebuggenie/js/thebuggenie.js
+++ b/thebuggenie/js/thebuggenie.js
@@ -3335,7 +3335,7 @@ TBG.Issues.markAsChanged = function(field)
 {
 	if (!$('viewissue_changed').visible()) {
 		$('viewissue_changed').show();
-		Effect.Pulsate($('issue_info_container'), {pulses: 6, duration: 2});
+		Effect.Pulsate($('issue_info_container'), {pulses: 3, duration: 2});
 	}
 	
 	$(field + '_field').addClassName('issue_detail_changed');


### PR DESCRIPTION
It's important to pulse the save changes prompt to get the users attention but it's hard to click the save button while it's flashing.

The prompt flashes 6 times which is a bit excessive, especially on client devices/browsers that do not have accelerated rendering of opacity effects. For example, on my main PC the flashing ends in ~3-4 seconds, but takes almost twice as long on my laptop.
