### PR TITLE
Fix timeline Issues XSS Vulnerability

### DIFF
--- a/modules/main/templates/_logitem.inc.php
+++ b/modules/main/templates/_logitem.inc.php
@@ -50,7 +50,7 @@
 						echo '<i>' . __('Issue created') . '</i>';
 						if (isset($include_details) && $include_details)
 						{
-							echo '<div class="timeline_inline_details">'.nl2br($issue->getDescription()).'</div>';
+							echo '<div class="timeline_inline_details">'.nl2br(htmlentities($issue->getDescription())).'</div>';
 						}
 						break;
 					case TBGLogTable::LOG_COMMENT:


### PR DESCRIPTION
This patch fixes a XSS vulnerability that was assigned CVE-2013-1760 (related to Issue #1897). Although a fix was proposed for the latest release version, I found that the issue still exists. When a user creates a new bug report that contains JavaScript in the description of the report, the code will be executed if anyone visits the project Timeline (stored XSS). For reference: www.thebuggenie.com/security/TBGSN-002-1
