### PR TITLE
Fix openid_identifier XSS Vulnerability

### DIFF
--- a/core/classes/LightOpenID.class.php
+++ b/core/classes/LightOpenID.class.php
@@ -213,7 +213,7 @@ class LightOpenID
     protected function request_streams($url, $method='GET', $params=array())
     {
         if(!$this->hostExists($url)) {
-            throw new ErrorException("Could not connect to $url.", 404);
+            throw new ErrorException("Could not connect to ".htmlentities($url), 404);
         }
 
         $params = http_build_query($params, '', '&');


### PR DESCRIPTION
This patch fixes a reflective XSS vulnerability that was assigned CVE-2013-1760 (related to Issue #1900). Although a fix was proposed for the latest release version, I found that the issue still exists. When login in, it is possible to insert the 'openid_identifier' parameter with JavaScript, causing an ErrorException that executes the code. For reference: www.thebuggenie.com/security/TBGSN-002-1
