### PR TITLE
Added support for RhodeCode to VCS integration module.

### DIFF
--- a/modules/vcs_integration/classes/TBGVCSIntegration.class.php
+++ b/modules/vcs_integration/classes/TBGVCSIntegration.class.php
@@ -298,6 +298,13 @@
 								$link_diff = '/commit/%revno%';
 								$link_view = '/blobs/%revno%/%file%';
 								break;
+							case 'rhodecode':
+								$base_url = $web_path . '/' . $web_repo;
+								$link_rev = '/changeset/%revno%';
+								$link_file = '/changelog/%revno%/%file%';
+								$link_diff = '/diff/%file%?diff2=%revno%&amp;diff1=%oldrev%&amp;fulldiff=1&amp;diff=diff';
+								$link_view = '/files/%revno%/%file%';
+								break;
 						}
 						$this->saveSetting('browser_url_'.$projectId, $base_url);
 						$this->saveSetting('log_url_'.$projectId, $link_file);

--- a/modules/vcs_integration/classes/actions.class.php
+++ b/modules/vcs_integration/classes/actions.class.php
@@ -491,6 +491,13 @@
 						$link_diff = '/commit/%revno%';
 						$link_view = '/blobs/%revno%/%file%';
 						break;
+					case 'rhodecode':
+						$base_url = $request['browser_url'];
+						$link_rev = '/changeset/%revno%';
+						$link_file = '/changelog/%revno%/%file%';
+						$link_diff = '/diff/%file%?diff2=%revno%&amp;diff1=%oldrev%&amp;fulldiff=1&amp;diff=diff';
+						$link_view = '/files/%revno%/%file%';
+						break;
 				}
 
 				if ($request['browser_type'] != 'other')

--- a/modules/vcs_integration/templates/_projectconfig_panel.inc.php
+++ b/modules/vcs_integration/templates/_projectconfig_panel.inc.php
@@ -69,6 +69,7 @@
 							</optgroup>
 							<optgroup label="Mercurial">
 								<option value='hgweb'>hgweb</option>
+								<option value='rhodecode'>RhodeCode</option>
 							</optgroup>
 							<optgroup label="Git">
 								<option value='gitweb'>gitweb</option>
@@ -76,6 +77,7 @@
 								<option value='gitorious'>Gitorious (<?php echo __('locally hosted'); ?>)</option>
 								<option value='github'>Github</option>
 								<option value='bitbucket'>Bitbucket</option>
+								<option value='rhodecode'>RhodeCode</option>
 							</optgroup>
 							<optgroup label="Bazaar">
 								<option value='loggerhead'>Loggerhead</option>


### PR DESCRIPTION
Adds support for RhodeCode (https://rhodecode.org/) in VCS integration module (changeset, file etc links).

The same code should work for both Git and Mercurial (RhodeCode translates between "tip" and "head" automatically).
