### PR TITLE
Update actions.class.php to support GitLab webhook format.

### DIFF
--- a/modules/vcs_integration/classes/actions.class.php
+++ b/modules/vcs_integration/classes/actions.class.php
@@ -154,7 +154,14 @@
 			$data = html_entity_decode(TBGContext::getRequest()->getParameter('payload'));
 			if (empty($data) || $data == null)
 			{
-				die('Error: No payload was provided');
+				//Need to check if payload is in unwrapped form from GitLab (until support is added)
+				//Obtain raw input from request
+				$data = file_get_contents("php://input");
+				if (empty($data) || $data == null)
+				{
+					die('Error: No payload was provided');
+				}
+				
 			}
 
 			$entries = json_decode($data);


### PR DESCRIPTION
GitLab does not wrap the request in a 'payload' parameter. Since there is no parameter to obtain, you can check and see if the raw request contains the required information. If so, you can proceed normally. This will allow TBG to accept wenhook data from GitLab and use the current Github functionality until such time as a GitLab option is added. No other changes seem to be required to allow GitLab to utilize this functionality.
