### PR TITLE
Update TBGVCSIntegration.class.php

### DIFF
--- a/modules/vcs_integration/classes/TBGVCSIntegration.class.php
+++ b/modules/vcs_integration/classes/TBGVCSIntegration.class.php
@@ -562,6 +562,10 @@
 				$user = TBGContext::factory()->TBGUser(TBGSettings::getDefaultUserID());
 				$uid = TBGSettings::getDefaultUserID();
 			}
+			
+			TBGContext::setUser($user);
+			TBGSettings::forceSettingsReload();
+			TBGContext::cacheAllPermissions();
 								
 			$output .= '[VCS '.$project->getKey().'] Commit to be logged by user ' . $user->getName() . "\n";
 


### PR DESCRIPTION
TBGContext::getUser()->getID() returned NULL in TBGMailing_getIssueRelatedUsers (file: TheBugGenie\modules\mailing\classes\TBGMailing.class.php) to fix this TBGContext::setUser has to executed before the comment is saved.

Fixes bug: http://issues.thebuggenie.com/thebuggenie/issues/2059
