### PR TITLE
auth_LDAP - integrated auth allow custom HTTP header field for user name...

### DIFF
--- a/modules/auth_ldap/classes/TBGLDAPAuthentication.class.php
+++ b/modules/auth_ldap/classes/TBGLDAPAuthentication.class.php
@@ -33,8 +33,6 @@
 		
 		protected $_has_config_settings = true;
 
-		protected $_user_header = 'REMOTE_USER';
-
 		/**
 		 * Return an instance of this module
 		 *
@@ -76,7 +74,7 @@
 
 		public function postConfigSettings(TBGRequest $request)
 		{
-			$settings = array('hostname', 'u_type', 'g_type', 'b_dn', 'groups', 'dn_attr', 'u_attr', 'g_attr', 'e_attr', 'f_attr', 'g_dn', 'control_user', 'control_pass', 'integrated_auth');
+			$settings = array('hostname', 'u_type', 'g_type', 'b_dn', 'groups', 'dn_attr', 'u_attr', 'g_attr', 'e_attr', 'f_attr', 'g_dn', 'control_user', 'control_pass', 'integrated_auth', 'integrated_auth_header');
 			foreach ($settings as $setting)
 			{
 				if (($setting == 'u_type' || $setting == 'g_type' || $setting == 'dn_attr') && $request->getParameter($setting) == '')
@@ -354,7 +352,7 @@
 				 */
 				elseif ($mode == 1) 
 				{
-					if (!isset($_SERVER[$this->_user_header]) || $_SERVER[$this->_user_header] != $username) 
+					if (!isset($_SERVER[$this->getSetting('integrated_auth_header')]) || $_SERVER[$this->getSetting('integrated_auth_header')] != $username) 
 					{
 						throw new Exception(TBGContext::geti18n()->__('HTTP authentication internal error.'));
 					}
@@ -452,9 +450,9 @@
 		{
 			if ($this->getSetting('integrated_auth')) 
 			{
-  				if (isset($_SERVER[$this->_user_header])) 
+  				if (isset($_SERVER[$this->getSetting('integrated_auth_header')])) 
 				{
-					return $this->doLogin($_SERVER[$this->_user_header],'a',1);
+					return $this->doLogin($_SERVER[$this->getSetting('integrated_auth_header')],'a',1);
 				}
 				else
 				{

--- a/modules/auth_ldap/templates/_settings.inc.php
+++ b/modules/auth_ldap/templates/_settings.inc.php
@@ -95,8 +95,15 @@
 				<td><input type="checkbox"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="integrated_auth" id="integrated_auth" value="1" value="1" <?php if ($module->getSetting('integrated_auth')): ?>checked<?php endif; ?> style="width: 100%;"></td>
 			</tr>
 			<tr>
-				<td class="config_explanation" colspan="2"><?php echo __('Activate to enabled automatic user login using HTTP integrated authentication. This requires your web server to be authenticating the user (e.g. HTTP Basic Authentication, Kerberos etc) and providing the "REMOTE_USER" HTTP header so Bug Genie can identify the current user. '); ?></td>
-			</tr>			
+				<td class="config_explanation" colspan="2"><?php echo __('Activate to enabled automatic user login using HTTP integrated authentication. This requires your web server to be authenticating the user (e.g. HTTP Basic Authentication, Kerberos etc). '); ?></td>
+			</tr>
+			<tr>
+				<td style="padding: 5px;"><label for="integrated_auth_header"><?php echo __('HTTP header field'); ?></label></td>
+				<td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="integrated_auth_header" id="integrated_auth_header" value="<?php echo $module->getSetting('integrated_auth_header'); ?>" style="width: 100%;"></td>
+			</tr>
+			<tr>
+				<td class="config_explanation" colspan="2"><?php echo __('If using HTTP integrated authentication specify the HTTP header field that will contain the user name.'); ?></td>
+			</tr>									
 		</table>
 	</div>
 <?php if ($access_level == TBGSettings::ACCESS_FULL): ?>


### PR DESCRIPTION
If using integrated auth to auto login users most sites are already have a HTTP header field that stores the user name so would need to change the code to conform to their field.  This change allows then to specify the user name as a setting.
