### PR TITLE
Fix for handling of initial commits to git repository and VCS integration

### DIFF
--- a/modules/vcs_integration/classes/actions.class.php
+++ b/modules/vcs_integration/classes/actions.class.php
@@ -77,7 +77,12 @@
 			}
 			
 			// Obtain previous revision
-			if (!TBGContext::getRequest()->hasParameter('oldrev'))
+			if (!TBGContext::getRequest()->hasParameter('oldrev') && !is_integer($new_rev))
+			{
+				echo 'Error: If only the new revision is specified, it must be a number so that old revision can be calculated from it (by substracting 1 from new revision number).';
+				exit;
+			}
+			else if (!TBGContext::getRequest()->hasParameter('oldrev'))
 			{
 				$old_rev = $new_rev - 1;
 			}
@@ -85,7 +90,7 @@
 			{
 				$old_rev = TBGContext::getRequest()->getParameter('oldrev'); // for git, etc. which use hashes
 			}
-			
+
 			// Obtain date timestamp
 			if (!TBGContext::getRequest()->hasParameter('date'))
 			{
@@ -100,12 +105,6 @@
 			if (empty($author) || empty($new_rev) || empty($commit_msg) || empty($changed))
 			{
 				echo 'Error: One of the required fields were not specified. The required fields are the author, revision number (or hash), commit log and a list of changed files';
-				exit;
-			}
-			
-			if ((!is_numeric($new_rev) && is_numeric($old_rev)) || (is_numeric($new_rev) && !is_numeric($old_rev)))
-			{
-				echo 'Error: If the old revision is specified, it must be the same format as the new revision (number or hash)';
 				exit;
 			}
 			

--- a/modules/vcs_integration/classes/cli/CliVCS_IntegrationReport.class.php
+++ b/modules/vcs_integration/classes/cli/CliVCS_IntegrationReport.class.php
@@ -55,7 +55,7 @@
 			$new_rev = $this->getProvidedArgument('revno');
 			$commit_msg = $this->getProvidedArgument('log');
 			$changed = $this->getProvidedArgument('changed');
-			$old_rev = $this->getProvidedArgument('oldrev', $new_rev - 1);
+			$old_rev = $this->getProvidedArgument('oldrev', null);
 			$date = $this->getProvidedArgument('date', null);
 			$branch = $this->getProvidedArgument('branch', null);
 			
@@ -65,12 +65,15 @@
 				exit;
 			}
 
-			if ((!is_numeric($new_rev) && is_numeric($old_rev)) || (is_numeric($new_rev) && !is_numeric($old_rev)))
+			if ($old_rev === null && !is_integer($new_rev))
 			{
-				$this->cliEcho("If the old revision is specified, it must be the same format as the new revision (number or hash)\n", 'red', 'bold');
-				exit;
+				$this->cliEcho("Error: if only the new revision is specified, it must be a number so that old revision can be calculated from it (by substracting 1 from new revision number).");
 			}
-			
+			else if ($old_rev === null)
+			{
+				$old_rev = $new_rev - 1;
+			}
+
 			$output = TBGVCSIntegration::processCommit($project, $commit_msg, $old_rev, $new_rev, $date, $changed, $author, $branch);
 			$this->cliEcho($output);
 		}

--- a/modules/vcs_integration/hooks/git/tbg-post-receive
+++ b/modules/vcs_integration/hooks/git/tbg-post-receive
@@ -26,9 +26,18 @@ update_tbg()
 
     #echo "Attempting to update tbg with oldhash:$oldhash newhash:$newhash"
     changedfiles=`git diff-tree --name-status -r $newhash --no-commit-id`
-    name=`git log ^$oldhash $newhash --pretty=format:"%an <%ae>"`
-    log=`git log ^$oldhash $newhash --pretty=format:"%s %b"`
-    time=`git log ^$oldhash $newhash --pretty=format:"%ct"`
+
+    # Retrieve name, log, and time. Make sure to use correct syntax for the
+    # first commit of repository (where there's no parent/oldrev).
+    if [ "$oldhash" = "0000000000000000000000000000000000000000" ]; then
+        name=`git log $newhash --pretty=format:"%an <%ae>"`
+        log=`git log $newhash --pretty=format:"%s %b"`
+        time=`git log $newhash --pretty=format:"%ct"`
+    else
+        name=`git log ^$oldhash $newhash --pretty=format:"%an <%ae>"`
+        log=`git log ^$oldhash $newhash --pretty=format:"%s %b"`
+        time=`git log ^$oldhash $newhash --pretty=format:"%ct"`
+    fi
 
     #echo "updating with name: $name"
     #echo "updating with log: $log"


### PR DESCRIPTION
This pull request should fix the issue #2208, allowing the first git commit to be stored in the TBG database. I had to modify the core code for VCS integration in addition to hook in order to allow this (the old code's logic was a bit flawed due to way how PHP converts '0000000000000' to an integer 0).

The patch has not been tested against master, though, since VCS integration seems to be a bit broken there (can't configure it). The patch still applied cleanly, though.
