### PR TITLE
var_dump removed from display

### DIFF
--- a/modules/search/templates/_interactivefilter.inc.php
+++ b/modules/search/templates/_interactivefilter.inc.php
@@ -357,4 +357,6 @@
 		}
 
 	?>
+<?php else: ?>
+	<?php var_dump($filter); ?>
 <?php endif; ?>


### PR DESCRIPTION
Following the issue I reported:
http://issues.thebuggenie.com/thebuggenie/issues/2363

Here is the fix and another location that also had var_dump
