### PR TITLE
Fix dead link to valid Oxygen icon source

### DIFF
--- a/modules/main/templates/about.html.php
+++ b/modules/main/templates/about.html.php
@@ -26,7 +26,7 @@
 	<?php echo __('Licensed under the MPL 1.1 only, read it at %link_to_MPL', array('%link_to_MPL' => '<a href="http://www.opensource.org/licenses/mozilla1.1.php">opensource.org</a>')); ?>.<br>
 	<br>
 	<span class="faded_out">
-		<?php echo __('The Bug Genie uses icons from the %link_to_iconset', array('%link_to_iconset' => '<a href="http://www.oxygen-icons.org">Oxygen icon set</a>')); ?>.<br>
+		<?php echo __('The Bug Genie uses icons from the %link_to_iconset', array('%link_to_iconset' => '<a href="https://sourceforge.net/projects/openiconlibrary">Oxygen icon set</a>')); ?>.<br>
 		<?php echo __('These icons may be freely distributed under the %link_to_license', array('%link_to_license' => '<a href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0 License</a>')); ?>.
 	</span>
 </div>


### PR DESCRIPTION
The oxygen-icons.org website is gone.  Did some research and discovered the KDE Oxygen icon set with a CC-BY-SA 3.0 or LGPL License once distributed by oxygen-icons.org, is now being distributed by https://sourceforge.net/projects/openiconlibrary with the blessing of prominent GNU/Linux/KDE developer Jonathan Riddell: http://comments.gmane.org/gmane.comp.kde.licensing/467.
