### PR TITLE
Fix #1489

### DIFF
--- a/core/classes/TBGContext.class.php
+++ b/core/classes/TBGContext.class.php
@@ -805,7 +805,7 @@
 			{
 				TBGLogging::log("Something happened while setting up user: ". $e->getMessage(), 'main', TBGLogging::LEVEL_WARNING);
 				$allow_anonymous_routes = array('register', 'register_check_username', 'register1', 'register2', 'activate', 'reset_password', 'captcha', 'login', 'login_page', 'getBackdropPartial', 'serve', 'doLogin');
-				if (!self::isCLI() && (!in_array(self::getRouting()->getCurrentRouteModule(), array('main', 'remote')) || !in_array(self::getRouting()->getCurrentRouteName(), $allow_anonymous_routes)))
+				if (!self::isCLI() && (!in_array(self::getRouting()->getCurrentRouteModule(), array('main', 'remote')) || !in_array(self::getRouting()->getCurrentRouteName(), $allow_anonymous_routes)) && !(self::getRouting()->getCurrentRouteModule() == "vcs_integration" && strpos(self::getRouting()->getCurrentRouteAction(), "addCommit") === 0))
 				{
 					TBGContext::setMessage('login_message_err', $e->getMessage());
 					self::$_redirect_login = 'login';


### PR DESCRIPTION
Fixes #1489.
This Pull request fixes a bug in TBG where the VCS integration plugin would fail to receive notifications
about new commits through the HTTP-API when guest access was denied.
Instead of redirecting the VCS hook request to the login page, it now gets to the right place.

Maybe this is not the most elegant way as this change affects a plugin but was done in `core` but it works and I did not find any other way to do this.

See: http://issues.thebuggenie.com/thebuggenie/issues/1489
