### PR TITLE
Require phpunit via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,14 @@
 		"easybook/geshi" : "dev-master",
 		"michelf/php-markdown" : "1.3",
 		"swiftmailer/swiftmailer" : "4.2.*",
-                "webit/eval-math" : "dev-master",
-                "lightopenid/lightopenid": "dev-master",
-                "mustangostang/spyc": "0.5.*",
-                "realityking/pchart": "dev-master"
+		"webit/eval-math" : "dev-master",
+		"lightopenid/lightopenid": "dev-master",
+		"mustangostang/spyc": "0.5.*",
+		"realityking/pchart": "dev-master"
 	},
 	"require-dev" : {
-		"symfony/finder" : "dev-master"
+		"symfony/finder" : "dev-master",
+		"phpunit/phpunit": "4.2.*"
 	},
         "autoload": {
             "psr-4" : {


### PR DESCRIPTION
... for easy testing in development environments. The binary will be installed in `/vendor/bin/phpunit` so tests can be execuded by:

```
vendor/bin/phpunit -c tests/
```

And replaced spaces by tabs for json files.
