### PR TITLE
Quick Links Entries With Headings Include a ^top Link

### DIFF
--- a/core/modules/main/templates/_menulink.inc.php
+++ b/core/modules/main/templates/_menulink.inc.php
@@ -1,16 +1,16 @@
 <li id="<?php echo $link['target_type']; ?>_<?php echo $link['target_id']; ?>_links_<?php echo $link_id; ?>" style="clear: both;">
     <?php if ($link['target_type'] == 'wiki' && $link['url'] != ''): ?>
         <?php if ($tbg_routing->getCurrentRouteModule() == 'publish' && $tbg_request['article_name'] == $link['url']): ?>
-            <?php echo link_tag(make_url('publish_article', array('article_name' => strip_tags($link['url']))), (($link['description'] != '') ? tbg_parse_text($link['description']) : strip_tags($link['url'])), array('class' => 'selected')); ?>
+            <?php echo link_tag(make_url('publish_article', array('article_name' => strip_tags($link['url']))), (($link['description'] != '') ? tbg_parse_text($link['description'], false, null, array('embedded' => true)) : strip_tags($link['url'])), array('class' => 'selected')); ?>
         <?php else: ?>
-            <?php echo link_tag(make_url('publish_article', array('article_name' => strip_tags($link['url']))), (($link['description'] != '') ? tbg_parse_text($link['description']) : strip_tags($link['url']))); ?>
+            <?php echo link_tag(make_url('publish_article', array('article_name' => strip_tags($link['url']))), (($link['description'] != '') ? tbg_parse_text($link['description'], false, null, array('embedded' => true)) : strip_tags($link['url']))); ?>
         <?php endif; ?>
     <?php elseif (mb_substr($link['url'], 0, 1) == '@'): ?>
-        <?php echo link_tag(make_url($link['url']), (($link['description'] != '') ? tbg_parse_text($link['description']) : strip_tags($link['url']))); ?>
+        <?php echo link_tag(make_url($link['url']), (($link['description'] != '') ? tbg_parse_text($link['description'], false, null, array('embedded' => true)) : strip_tags($link['url']))); ?>
     <?php elseif ($link['url'] != ''): ?>
-        <?php echo link_tag($link['url'], (($link['description'] != '') ? tbg_parse_text($link['description']) : strip_tags($link['url']))); ?>
+        <?php echo link_tag($link['url'], (($link['description'] != '') ? tbg_parse_text($link['description'], false, null, array('embedded' => true)) : strip_tags($link['url']))); ?>
     <?php elseif ($link['description'] != ''): ?>
-        <?php echo tbg_parse_text($link['description']); ?>
+        <?php echo tbg_parse_text($link['description'], false, null, array('embedded' => true)); ?>
     <?php else: ?>
         &nbsp;
     <?php endif; ?>

--- a/thebuggenie/themes/oxygen/oxygen.css
+++ b/thebuggenie/themes/oxygen/oxygen.css
@@ -3695,11 +3695,11 @@ h3 .dropdown_box a, h3 .dropdown_box a:hover { font-size: 0.7em; text-transform:
 
 /* menu links */
 .menu_links .header { font-size: 1em; border-bottom: 0; font-weight: bold; margin-bottom: 5px; }
-.menu_links .content li { font-size: 1.0em; padding: 1px; height: 20px; }
+.menu_links .content li { font-size: 1.0em; padding: 1px; min-height: 20px; }
 .menu_links .content a { font-weight: bold; }
 .menu_links .content a.selected { font-weight: bold; color: #006700; }
 .menu_links .content a.selected:hover { font-weight: bold; color: #00a400; }
-.menu_links .content .delete-icon { display: none; }
+.menu_links .content .delete-icon { display: none; z-index: 10; }
 .menu_links li { cursor: default; }
 .menu_links.menu_editing .content .delete-icon { display: inline; }
 .menu_links.menu_editing li:hover { cursor: move; background-color: rgba(230, 230, 230, 0.4); }


### PR DESCRIPTION
Any generated headers for the quick link description should not include
a shortcut ^top link.

In addition, for long descriptions, we need to ensure that
   1) the box can grow to accommodate the increased size and
   2) that the "x" delete button is always clickable

This commit addresses issue #1611
