### PR TITLE
Duplicate Edition IDs In Use on Release Center

### DIFF
--- a/core/classes/TBGBuild.class.php
+++ b/core/classes/TBGBuild.class.php
@@ -218,7 +218,7 @@
          */
         public function isEditionBuild()
         {
-            return !is_null($this->_edition);
+            return (bool) $this->_edition;
         }
 
         /**

--- a/core/classes/TBGProject.class.php
+++ b/core/classes/TBGProject.class.php
@@ -1560,6 +1560,13 @@
             return $this->_builds;
         }
 
+        public function getNonEditionBuilds()
+        {
+            return array_filter($this->getBuilds(), function ($build) {
+                return $build->isEditionBuild() == false;
+            });
+        }
+
         public function getActiveBuilds()
         {
             $builds = $this->getBuilds();

--- a/core/modules/project/templates/releasecenter.html.php
+++ b/core/modules/project/templates/releasecenter.html.php
@@ -22,14 +22,14 @@
                 </div>
             <?php endif; ?>
             <h3><?php echo __('Project releases'); ?></h3>
-            <ul class="simple_list" id="builds_0">
-                <?php if (count($selected_project->getBuilds())): ?>
-                    <?php foreach ($selected_project->getBuilds() as $build): ?>
+            <ul class="simple_list" id="active_builds_0">
+                <?php if (count($selected_project->getNonEditionBuilds())): ?>
+                    <?php foreach ($selected_project->getNonEditionBuilds() as $build): ?>
                         <?php include_component('buildbox', array('build' => $build)); ?>
                     <?php endforeach; ?>
                 <?php endif; ?>
             </ul>
-            <div class="faded_out" id="no_builds_0"<?php if (count($selected_project->getBuilds())): ?> style="display: none;"<?php endif; ?>><?php echo __('There are no releases for this project'); ?></div>
+            <div class="faded_out" id="no_active_builds_0"<?php if (count($selected_project->getNonEditionBuilds())): ?> style="display: none;"<?php endif; ?>><?php echo __('There are no releases for this project'); ?></div>
             <?php if ($selected_project->isEditionsEnabled()): ?>
                 <?php foreach ($selected_project->getEditions() as $edition_id => $edition): ?>
                     <h3><?php echo __('%edition_name releases', array('%edition_name' => $edition->getName())); ?></h3>
@@ -40,7 +40,7 @@
                             <?php endforeach; ?>
                         <?php endif; ?>
                     </ul>
-                    <div class="faded_out" id="no_builds_<?php echo $edition_id; ?>"<?php if (count($edition->getBuilds())): ?> style="display: none;"<?php endif; ?>><?php echo __('There are no releases for this edition'); ?></div>
+                    <div class="faded_out" id="no_active_builds_<?php echo $edition_id; ?>"<?php if (count($edition->getBuilds())): ?> style="display: none;"<?php endif; ?>><?php echo __('There are no releases for this edition'); ?></div>
                 <?php endforeach; ?>
             <?php endif; ?>
         </div>


### PR DESCRIPTION
Instead of showing edition builds under "Project Releases" and "Edition
Releases", this commit only shows them under the appropriate Edition
section.  This prevents the issue of having duplicate IDs on the page.

This commit also fixes a bug where TBGBuild::isEditionBuild() was
incorrectly identifying builds as being associated with an addition.
The edition ID was 0 instead of null.

Finally, some of the markup was modified so that when the final build
was removed from any section, the muted text informing the user that
there are no releases for the project / edition is restored.

This issue fixes #2459
