### PR TITLE
Fix Composer install process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "mustangostang/spyc": "0.5.*",
         "realityking/pchart": "dev-master",
         "ext-gd" : "*",
-        "ext-gmp" : "*",
         "ext-curl" : "*",
         "ext-PDO" : "*",
         "ext-iconv" : "*",
@@ -31,7 +30,7 @@
         "lib-pcre" : "8.*"
     },
     "require-dev" : {
-        "symfony/finder" : "dev-master",
+        "symfony/finder" : "~2.7",
         "phpunit/phpunit": "4.2.*"
     },
     "suggest" : {
@@ -41,8 +40,7 @@
         "psr-4" : {
             "thebuggenie\\modules\\" : "modules/",
             "thebuggenie\\core\\" : "core/"
-        },
-        "classmap" : [ "core/classes/", "core/classes/B2DB/" ]
+        }
     },
     "minimum-stability" : "dev",
         "prefer-stable" : true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a4ca093f19719c30a9dde3ce69e137cc",
+    "hash": "63915bd675d8480ee4bc115339400457",
     "packages": [
         {
             "name": "easybook/geshi",
@@ -315,12 +315,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/thebuggenie/b2db.git",
-                "reference": "095003a90cf14717af102fd7cc0e335e894adc56"
+                "reference": "6c95840d01dcd34f645609c9d036a35c88338ee2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thebuggenie/b2db/zipball/095003a90cf14717af102fd7cc0e335e894adc56",
-                "reference": "095003a90cf14717af102fd7cc0e335e894adc56",
+                "url": "https://api.github.com/repos/thebuggenie/b2db/zipball/6c95840d01dcd34f645609c9d036a35c88338ee2",
+                "reference": "6c95840d01dcd34f645609c9d036a35c88338ee2",
                 "shasum": ""
             },
             "require": {
@@ -344,7 +344,7 @@
                 }
             ],
             "description": "B2DB is a lightweight PHP 5.3-based ORM",
-            "time": "2014-12-12 07:02:26"
+            "time": "2015-01-22 14:26:49"
         },
         {
             "name": "webit/eval-math",
@@ -1073,26 +1073,26 @@
         },
         {
             "name": "symfony/finder",
-            "version": "dev-master",
+            "version": "2.7.x-dev",
             "target-dir": "Symfony/Component/Finder",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Finder.git",
-                "reference": "37634be207646b5f9a8f550424d1a877731d37bd"
+                "reference": "0c737de96a94d14a51738d285ad426a102baac0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/37634be207646b5f9a8f550424d1a877731d37bd",
-                "reference": "37634be207646b5f9a8f550424d1a877731d37bd",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/0c737de96a94d14a51738d285ad426a102baac0e",
+                "reference": "0c737de96a94d14a51738d285ad426a102baac0e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
@@ -1116,7 +1116,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "http://symfony.com",
-            "time": "2015-01-03 08:04:30"
+            "time": "2015-01-09 06:51:41"
         },
         {
             "name": "symfony/yaml",
@@ -1174,13 +1174,12 @@
         "easybook/geshi": 20,
         "webit/eval-math": 20,
         "lightopenid/lightopenid": 20,
-        "realityking/pchart": 20,
-        "symfony/finder": 20
+        "realityking/pchart": 20
     },
     "prefer-stable": true,
+    "prefer-lowest": false,
     "platform": {
         "ext-gd": "*",
-        "ext-gmp": "*",
         "ext-curl": "*",
         "ext-pdo": "*",
         "ext-iconv": "*",


### PR DESCRIPTION
* The Symfony 3.0 branch chose for php >= 5.5.9 so you should require `symfony/finder:~2.7`
* You should suggest using `ext-gmp` instead of requiring it. My installation crashed on this, TBG does not rely on it.
* The `autoload` classmap is not needed, because B2DB is required via Composer seperately and `core/` already is in the `psr-4` autoload
