### PR TITLE
Fix for guest user access

### DIFF
--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -667,6 +667,11 @@
                         }
                 }
 
+                if ($user === null && !framework\Settings::isLoginRequired())
+                    {
+                        $user = self::getB2DBTable()->getByUserID(framework\Settings::getDefaultUserID());
+                    }
+
                 if ($user instanceof User)
                 {
                     if (!$user->isActivated())

--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -660,11 +660,6 @@
                         $user = self::getB2DBTable()->getByUsername($request['api_username']);
                         if (!$user->authenticateApplicationPassword($request['api_token'])) $user = null;
                         break;
-                    default:
-                        if (!framework\Settings::isLoginRequired())
-                        {
-                            $user = self::getB2DBTable()->getByUserID(framework\Settings::getDefaultUserID());
-                        }
                 }
 
                 if ($user === null && !framework\Settings::isLoginRequired())


### PR DESCRIPTION
Once the regular authentication methods have been attempted, if user is still not logged-in, and login is not required (guest access is denied), log-in the user with a guest account. Resolves issue #2518.

I have not been able to verify this patch works against actual master since I could not install from master. However, I did test the patch against the tag v4.0-rc.1, and there it has worked as expected. I'm not 100% sure I understand what the "Guest user is authenticated" option does, and if I should take it into account somehow, though.