### PR TITLE
Fix reuse of database configuration during CLI installation

### DIFF
--- a/core/modules/main/cli/Install.php
+++ b/core/modules/main/cli/Install.php
@@ -25,6 +25,7 @@
         {
             $this->_command_name = 'install';
             $this->_description = "Run the installation routine";
+            $this->_b2db_config_file = \THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml";
             $this->addOptionalArgument('accept_license', 'Set to "yes" to auto-accept license');
             $this->addOptionalArgument('url_subdir', 'Specify URL subdirectory');
             $this->addOptionalArgument('use_existing_db_info', 'Set to "yes" to use existing db information if available');
@@ -115,7 +116,7 @@
                 else
                 {
                     $this->cliEcho("Step 1 - database information\n");
-                    if (file_exists(\THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml"))
+                    if (file_exists($this->_b2db_config_file))
                     {
                         $this->cliEcho("You seem to already have completed this step successfully.\n");
                         if ($this->getProvidedArgument('use_existing_db_info') == 'yes')
@@ -210,29 +211,29 @@
                         $this->cliEcho("\n");
                         $this->cliEcho("Saving database connection information ... ", 'white', 'bold');
                         $this->cliEcho("\n");
-                        \b2db\Core::saveConnectionParameters(\THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml");
+                        \b2db\Core::saveConnectionParameters($this->$_b2db_config_file);
                         $this->cliEcho("Successfully saved database connection information.\n", 'green');
                         $this->cliEcho("\n");
                     }
                     else
                     {
-                        $b2db_config = \Spyc::YAMLLoad(\THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml");
+                        $b2db_config = \Spyc::YAMLLoad($this->_b2db_config_file);
 
                         if (!array_key_exists("b2db", $b2db_config))
                         {
-                            throw new \Exception("Could not find database configuration in file " . \THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml");
+                            throw new \Exception("Could not find database configuration in file " . $this->_b2db_config_file);
                         }
 
                         try
                         {
-                            \b2db\Core::initialize($b2db_config, \thebuggenie\core\framework\Context::getCache());
+                            \b2db\Core::initialize($b2db_config["b2db"], \thebuggenie\core\framework\Context::getCache());
                             \b2db\Core::doConnect();
                         }
                         catch (\Exception $e)
                         {
                             throw new \Exception("Could not connect to the database:\n" .
                                                  $e->getMessage() . "\nPlease check your configuration file " .
-                                                 \THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml" );
+                                                 $this->_b2db_config_file);
                         }
 
                         $this->cliEcho("Successfully connected to the database.\n", 'green');

--- a/core/modules/main/cli/Install.php
+++ b/core/modules/main/cli/Install.php
@@ -115,7 +115,7 @@
                 else
                 {
                     $this->cliEcho("Step 1 - database information\n");
-                    if (file_exists('core/b2db_bootstrap.inc.php'))
+                    if (file_exists(\THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml"))
                     {
                         $this->cliEcho("You seem to already have completed this step successfully.\n");
                         if ($this->getProvidedArgument('use_existing_db_info') == 'yes')
@@ -216,13 +216,26 @@
                     }
                     else
                     {
-                        \b2db\Core::initialize(THEBUGGENIE_CORE_PATH . 'b2db_bootstrap.inc.php');
-                        $this->cliEcho("Successfully connected to the database.\n", 'green');
-                        if ($this->getProvidedArgument('use_existing_db_info') != 'yes')
+                        $b2db_config = \Spyc::YAMLLoad(\THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml");
+
+                        if (!array_key_exists("b2db", $b2db_config))
                         {
-                            $this->cliEcho("Press ENTER to continue ... ");
-                            $this->pressEnterToContinue();
+                            throw new \Exception("Could not find database configuration in file " . \THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml");
                         }
+
+                        try
+                        {
+                            \b2db\Core::initialize($b2db_config, \thebuggenie\core\framework\Context::getCache());
+                            \b2db\Core::doConnect();
+                        }
+                        catch (\Exception $e)
+                        {
+                            throw new \Exception("Could not connect to the database:\n" .
+                                                 $e->getMessage() . "\nPlease check your configuration file " .
+                                                 \THEBUGGENIE_CONFIGURATION_PATH . "b2db.yml" );
+                        }
+
+                        $this->cliEcho("Successfully connected to the database.\n", 'green');
                     }
                     $this->cliEcho("\nThe Bug Genie needs some server settings to function properly...\n\n");
 

--- a/core/modules/main/cli/Install.php
+++ b/core/modules/main/cli/Install.php
@@ -211,7 +211,7 @@
                         $this->cliEcho("\n");
                         $this->cliEcho("Saving database connection information ... ", 'white', 'bold');
                         $this->cliEcho("\n");
-                        \b2db\Core::saveConnectionParameters($this->$_b2db_config_file);
+                        \b2db\Core::saveConnectionParameters($this->_b2db_config_file);
                         $this->cliEcho("Successfully saved database connection information.\n", 'green');
                         $this->cliEcho("\n");
                     }


### PR DESCRIPTION
This pull request fixes the installation of TBG using the CLI when database configuration file is already present. Useful for quicker testing of installation process (from CLI at least).