### PR TITLE
Change style for "Configure issue types" and "Issuetype scheme" proposal

### DIFF
--- a/core/modules/configuration/templates/_issuetype.inc.php
+++ b/core/modules/configuration/templates/_issuetype.inc.php
@@ -63,11 +63,11 @@
                         <?php if (!$scheme->isCore()): ?>
                             <td style="vertical-align: top; padding-top: 5px;"><label for="issuetype_<?php echo $type->getID(); ?>_reportable"><?php echo __('Reportable'); ?></label></td>
                         <?php endif; ?>
-                        <td>
+                        <td style="padding-left: 2px;">
                             <?php if ($scheme->isCore()): ?>
                                 <?php echo ($scheme->isIssuetypeReportable($type)) ? __('Users can report new issues with this issue type') : __('Users cannot report new issues with this issue type, but may choose it when editing an issue'); ?>
                             <?php else: ?>
-                                <select name="reportable" id="issuetype_<?php echo $type->getID(); ?>_reportable">
+                                <select name="reportable" id="issuetype_<?php echo $type->getID(); ?>_reportable" style="width:100%">
                                     <option value="1"<?php if ($scheme->isIssuetypeReportable($type)): ?> selected<?php endif; ?>><?php echo __('Users can report new issues with this issue type'); ?></option>
                                     <option value="0"<?php if (!$scheme->isIssuetypeReportable($type)): ?> selected<?php endif; ?>><?php echo __('Users cannot report new issues with this issue type, but may choose it when editing an issue'); ?></option>
                                 </select>
@@ -79,11 +79,11 @@
                         <?php if (!$scheme->isCore()): ?>
                             <td style="vertical-align: top; padding-top: 5px;"><label for="issuetype_<?php echo $type->getID(); ?>_redirect"><?php echo __('Redirect'); ?></label></td>
                         <?php endif; ?>
-                        <td>
+                        <td style="padding-left: 2px;">
                             <?php if ($scheme->isCore()): ?>
                                 <?php echo ($scheme->isIssuetypeRedirectedAfterReporting($type)) ? __('The user is redirected to the reported issue after it has been reported') : __('A blank "%report_issue" page with a link to the reported issue at the top will be shown after the issue is reported', array('%report_issue' => __('Report issue'))); ?>
                             <?php else: ?>
-                                <select name="redirect_after_reporting" id="issuetype_<?php echo $type->getID(); ?>_redirect">
+                                <select name="redirect_after_reporting" id="issuetype_<?php echo $type->getID(); ?>_redirect" style="width:100%">
                                     <option value="1"<?php if ($scheme->isIssuetypeRedirectedAfterReporting($type)): ?> selected<?php endif; ?>><?php echo __('The user is redirected to the reported issue after it has been reported'); ?></option>
                                     <option value="0"<?php if (!$scheme->isIssuetypeRedirectedAfterReporting($type)): ?> selected<?php endif; ?>><?php echo __('A blank "%report_issue" page with a link to the reported issue at the top will be shown after the issue is reported', array('%report_issue' => __('Report issue'))); ?></option>
                                 </select>

--- a/core/modules/configuration/templates/configureissuetypes.html.php
+++ b/core/modules/configuration/templates/configureissuetypes.html.php
@@ -7,7 +7,7 @@
     <tr>
         <?php include_component('leftmenu', array('selected_section' => 6)); ?>
         <td valign="top" style="padding-left: 15px;">
-            <div style="width: 730px;" id="config_issuetypes">
+            <div style="width: 780px;" id="config_issuetypes">
                 <h3><?php echo __('Configure issue types'); ?></h3>
                 <div class="content faded_out">
                     <p>
@@ -51,7 +51,7 @@
                             </div>
                         </div>
                     <?php elseif ($mode == 'schemes'): ?>
-                        <div id="tab_schemes_pane" style="padding-top: 0; width: 730px;">
+                        <div id="tab_schemes_pane" style="padding-top: 0; width: 780px;">
                             <div class="content">
                                 <?php echo __('In this tab you can add/remove/edit issue type schemes. If you add a new issue type on the previous tab, you must associate it with an issue type scheme in this tab to get it to show up for users.'); ?><br>
                                 <br>
@@ -64,7 +64,7 @@
                             </ul>
                         </div>
                     <?php elseif ($mode == 'scheme'): ?>
-                        <div id="tab_scheme_pane" style="padding-top: 0; width: 730px;">
+                        <div id="tab_scheme_pane" style="padding-top: 0; width: 780px;">
                             <div class="content">
                                 <?php echo __('In this tab you can edit issue type associations for this issue type scheme. Enable/disable available issue types, and set options such as reportable issue types and reportable/visible/required issue details.'); ?>
                             </div>


### PR DESCRIPTION
When configuring an issuetype scheme, the dropdown box for the
"Redirect" option was always larger than the box it was embedded into.
Since word wrap is not possible for plain HTML select boxes the whole
"Configure issue types" style needed to be adapted a little bit. It is
now 50 pixel larger than the other tabs (which no one notices) and the
size of the select boxes (including padding) were adapted.