### PR TITLE
Add the ability for themes to override the layout

### DIFF
--- a/core/framework/Response.php
+++ b/core/framework/Response.php
@@ -109,6 +109,13 @@
         protected $_template = '';
 
         /**
+         * Current layout path
+         *
+         * @var string
+         */
+        protected $_layout_path = '';
+
+        /**
          * What decoration to use (default normal)
          *
          * @var integer
@@ -198,6 +205,26 @@
         public function getTemplate()
         {
             return $this->_template;
+        }
+
+        /**
+         * Set the layout path
+         *
+         * @param string $layout_path The layout path
+         */
+        public function setLayoutPath($layout_path)
+        {
+            $this->_layout_path = $layout_path;
+        }
+
+        /**
+         * Return current layout path
+         *
+         * @return string
+         */
+        public function getLayoutPath()
+        {
+            return $this->_layout_path;
         }
 
         /**


### PR DESCRIPTION
Add a new layout_path property to the Response class and two new events
to Context so themes and modules can hook into the rendering and change
the layout and offline template paths. This will enable themes and
modules to override the default layout without editing core files.

Example:
```php                                                                                                                     
framework\Event::listen('core', '\thebuggenie\core\framework\Context::renderBegins', array($this, 'renderBegins'));

public function renderBegins() 
{
  // this will result in loading /var/www/thebuggenie/themes/custom/templates/layout.php
  framework\Context::getResponse()->setLayoutPath('/var/www/thebuggenie/themes/custom/templates');
}                                            
```