### PR TITLE
Add table annotation to empty module class fixture

### DIFF
--- a/core/modules/main/fixtures/emptymoduleclass
+++ b/core/modules/main/fixtures/emptymoduleclass
@@ -19,6 +19,8 @@
      *
      * @package module_key
      * @subpackage core
+     *
+     * @Table(name="\thebuggenie\core\entities\tables\Modules")
      */
     class module_name extends \thebuggenie\core\entities\Module
     {


### PR DESCRIPTION
The table annotation is missing from the current empty module class
fixture, therefore the newly generated empty modules will throw an error
at installation, eg.:

> The class '\thebuggenie\modules\newmodule\Newmodule' is missing a valid @Table annotation
> An exception was thrown in the B2DB framework