### PR TITLE
EMails : Encode subject with utf-8 (to support other languages)

### DIFF
--- a/modules/mailing/classes/TBGMailer.class.php
+++ b/modules/mailing/classes/TBGMailer.class.php
@@ -139,11 +139,11 @@
 
 			if (!$this->no_dash_f)
 			{
-				$retval = mail($email->getRecipientsAsString(), $email->getSubject(), $email->getBodyAsString(), $email->getHeadersAsString(false, false), '-f'.$email->getFromAddress());
+				$retval = mail($email->getRecipientsAsString(), '=?utf-8?B?'.base64_encode($email->getSubject()).'?=', $email->getBodyAsString(), $email->getHeadersAsString(false, false), '-f'.$email->getFromAddress());
 			}
 			else
 			{
-				$retval = mail($email->getRecipientsAsString(), $email->getSubject(), $email->getBodyAsString(), $email->getHeadersAsString(false, false));
+				$retval = mail($email->getRecipientsAsString(), '=?utf-8?B?'.base64_encode($email->getSubject()).'?=', $email->getBodyAsString(), $email->getHeadersAsString(false, false));
 			}
 			if ($retval)
 			{


### PR DESCRIPTION
Hebrew mails were not seen correctly, may help other langs as well
, should not have negative effects