### PR TITLE
Made it possible to configure anonymous routes in route configuration.

### DIFF
--- a/core/entities/Module.php
+++ b/core/entities/Module.php
@@ -342,10 +342,10 @@
             return false;
         }
 
-        public function addRoute($key, $url, $function, $params = array(), $csrf_enabled = false, $module_name = null)
+        public function addRoute($key, $url, $function, $params = array(), $options = array(), $module_name = null)
         {
             $module_name = ($module_name !== null) ? $module_name : $this->getName();
-            $this->_routes[] = array($key, $url, $module_name, $function, $params, $csrf_enabled);
+            $this->_routes[] = array($key, $url, $module_name, $function, $params, $options);
         }
 
         final public function initialize()

--- a/core/framework/Context.php
+++ b/core/framework/Context.php
@@ -618,8 +618,17 @@
             catch (\Exception $e)
             {
                 Logging::log("Something happened while setting up user: " . $e->getMessage(), 'main', Logging::LEVEL_WARNING);
-                $allow_anonymous_routes = array('register', 'register_check_username', 'register1', 'register2', 'activate', 'reset_password', 'captcha', 'login', 'login_page', 'getBackdropPartial', 'doLogin');
-                if (!self::isCLI() && (!in_array(self::getRouting()->getCurrentRouteModule(), array('main', 'remote')) || !in_array(self::getRouting()->getCurrentRouteName(), $allow_anonymous_routes)))
+
+                $is_anonymous_route = self::isCLI() || self::getRouting()->isCurrentRouteAnonymousRoute();
+
+                // Handle old static anoymous route configuration
+                if (!$is_anonymous_route)
+                {
+                    $allow_anonymous_routes = array('register', 'register_check_username', 'register1', 'register2', 'activate', 'reset_password', 'captcha', 'login', 'login_page', 'getBackdropPartial', 'doLogin');
+                    $is_anonymous_route = (in_array(self::getRouting()->getCurrentRouteModule(), array('main', 'remote')) && in_array(self::getRouting()->getCurrentRouteName(), $allow_anonymous_routes));
+                }
+
+                if (!$is_anonymous_route)
                 {
                     self::setMessage('login_message_err', $e->getMessage());
                     self::$_redirect_login = 'login';


### PR DESCRIPTION
VCS integrations need to have a possibility to make requests without requiring login. Passkey will be used to authenticate VCS web hook. This change makes it possible to configure in VCS code itself how it needs to behave. Same mechanism can be used for other pages like /login in future to remove fixed list of anonymous routes.

Both routes.yml/anonymous_route:true and @AnonymousRoute annotation is supported.

Signed-off-by: Vesa Jääskeläinen <dachaac@gmail.com>