### PR TITLE
Displayname formatting

### DIFF
--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -910,7 +910,15 @@
             {
                 return framework\Context::getI18n()->__('No such user');
             }
-            return ($this->_buddyname) ? $this->_buddyname : (($this->_realname) ? $this->_realname : $this->_username);
+            switch (framework\Settings::getUserDisplaynameFormat())
+            {
+                case framework\Settings::USER_DISPLAYNAME_FORMAT_REALNAME:
+                    return ($this->_realname) ? $this->_realname : $this->_username;
+
+                case framework\Settings::USER_DISPLAYNAME_FORMAT_BUDDY:
+                default:
+                    return ($this->_buddyname) ? $this->_buddyname : (($this->_realname) ? $this->_realname : $this->_username);
+            }
         }
 
         /**
@@ -938,7 +946,15 @@
             {
                 return $this->_buddyname;
             }
-            return ($this->_buddyname) ? $this->_buddyname . ' (' . $this->_username . ')' : $this->_username;
+            switch (framework\Settings::getUserDisplaynameFormat())
+            {
+                case framework\Settings::USER_DISPLAYNAME_FORMAT_REALNAME:
+                    return ($this->_realname) ? $this->_realname . ' (' . $this->_username . ')' : $this->_username;
+
+                case framework\Settings::USER_DISPLAYNAME_FORMAT_BUDDY:
+                default:
+                    return ($this->_buddyname) ? $this->_buddyname . ' (' . $this->_username . ')' : (($this->_realname) ? $this->_realname . ' (' . $this->_username . ')' : $this->_username);
+            }
         }
 
         public function __toString()

--- a/core/framework/Settings.php
+++ b/core/framework/Settings.php
@@ -107,6 +107,7 @@
         const SETTING_UPLOAD_MAX_FILE_SIZE = 'upload_max_file_size';
         const SETTING_UPLOAD_RESTRICTION_MODE = 'upload_restriction_mode';
         const SETTING_UPLOAD_STORAGE = 'upload_storage';
+        const SETTING_USER_DISPLAYNAME_FORMAT = 'user_displayname_format';
         const SETTING_USER_GROUP = 'defaultgroup';
         const SETTING_USER_TIMEZONE = 'timezone';
         const SETTING_USER_KEYBOARD_NAVIGATION = 'keyboard_navigation';
@@ -123,6 +124,9 @@
         const SETTING_ICONSET = 'iconset';
 
         const USER_RSS_KEY = 'rsskey';
+
+        const USER_DISPLAYNAME_FORMAT_REALNAME = 1;
+        const USER_DISPLAYNAME_FORMAT_BUDDY = 0;
 
         protected static $_ver_mj = 4;
         protected static $_ver_mn = 0;
@@ -410,6 +414,14 @@
                 return false; // No openID when using external auth
             }
             return (bool) self::isPersonaEnabled();
+        }
+
+        public static function getUserDisplaynameFormat()
+        {
+            $format = self::get(self::SETTING_USER_DISPLAYNAME_FORMAT);
+            if (!is_numeric($format))
+                $format = 0;
+            return (int) $format;
         }
 
         public static function isGravatarsEnabled()

--- a/core/modules/configuration/Actions.php
+++ b/core/modules/configuration/Actions.php
@@ -102,7 +102,7 @@
             if (framework\Context::getRequest()->isPost())
             {
                 $this->forward403unless($this->access_level == framework\Settings::ACCESS_FULL);
-                $settings = array(framework\Settings::SETTING_ENABLE_GRAVATARS, framework\Settings::SETTING_IS_SINGLE_PROJECT_TRACKER,
+                $settings = array(framework\Settings::SETTING_USER_DISPLAYNAME_FORMAT, framework\Settings::SETTING_ENABLE_GRAVATARS, framework\Settings::SETTING_IS_SINGLE_PROJECT_TRACKER,
                     framework\Settings::SETTING_REQUIRE_LOGIN, framework\Settings::SETTING_ALLOW_REGISTRATION, framework\Settings::SETTING_ALLOW_OPENID, framework\Settings::SETTING_USER_GROUP,
                     framework\Settings::SETTING_RETURN_FROM_LOGIN, framework\Settings::SETTING_RETURN_FROM_LOGOUT, framework\Settings::SETTING_IS_PERMISSIVE_MODE, framework\Settings::SETTING_ALLOW_PERSONA,
                     framework\Settings::SETTING_REGISTRATION_DOMAIN_WHITELIST, framework\Settings::SETTING_SHOW_PROJECTS_OVERVIEW, framework\Settings::SETTING_KEEP_COMMENT_TRAIL_CLEAN,

--- a/core/modules/configuration/templates/_user.inc.php
+++ b/core/modules/configuration/templates/_user.inc.php
@@ -56,6 +56,18 @@
         </td>
     </tr>
     <tr>
+        <td><label for="displayname_format"><?php echo __('User\'s display name format'); ?></label></td>
+        <td>
+            <select name="<?php echo \thebuggenie\core\framework\Settings::SETTING_USER_DISPLAYNAME_FORMAT; ?>" id="displayname_format" style="width: 400px;"<?php if ($access_level != \thebuggenie\core\framework\Settings::ACCESS_FULL): ?> disabled<?php endif; ?>>
+                <option value=1<?php if (\thebuggenie\core\framework\Settings::getUserDisplaynameFormat() == 1): ?> selected<?php endif; ?>><?php echo __('Use user\'s real name instead of buddy name'); ?></option>
+                <option value=0<?php if (\thebuggenie\core\framework\Settings::getUserDisplaynameFormat() == 0): ?> selected<?php endif; ?>><?php echo __('Prefer buddy name instead of real name.'); ?></option>
+            </select>
+            <?php echo config_explanation(
+                __('Change here how user\'s name is displayed.')
+            ); ?>
+        </td>
+    </tr>
+    <tr>
         <td><label for="allowreg"><?php echo __('Gravatar user icons'); ?></label></td>
         <td>
             <select name="<?php echo \thebuggenie\core\framework\Settings::SETTING_ENABLE_GRAVATARS; ?>" id="allowreg" style="width: 400px;"<?php if ($access_level != \thebuggenie\core\framework\Settings::ACCESS_FULL): ?> disabled<?php endif; ?>>

--- a/modules/mailing/Mailing.php
+++ b/modules/mailing/Mailing.php
@@ -307,7 +307,7 @@ EOT;
                     $message = $this->getSwiftMessage($translated_subject, $body_parts[0], $body_parts[1]);
                     foreach ($users as $user)
                     {
-                        $message->addTo($user->getEmail(), $user->getBuddyname());
+                        $message->addTo($user->getEmail(), $user->getName());
                     }
                     $messages[] = $message;
                     framework\Context::getI18n()->setLanguage($current_language);

--- a/modules/mailing/templates/_articlecomment.html.inc.php
+++ b/modules/mailing/templates/_articlecomment.html.inc.php
@@ -1,7 +1,7 @@
 <?php if ($article instanceof \thebuggenie\modules\publish\entities\Article && $comment instanceof \thebuggenie\core\entities\Comment): ?>
     <h3><?php echo $article->getTitle(); ?></h3>
     <br>
-    <h4><?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getBuddyname())) . ' ( ' . $comment->getPostedBy()->getUsername() . ')'; ?></h4>
+    <h4><?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getNameWithUsername())); ?></h4>
     <p><?php echo $comment->getParsedContent(); ?></p>
     <br>
     <div style="color: #888;">

--- a/modules/mailing/templates/_articlecomment.text.inc.php
+++ b/modules/mailing/templates/_articlecomment.text.inc.php
@@ -3,7 +3,7 @@
 <?php echo __('A comment has been posted:'); ?>
 
 
-* <?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getBuddyname())) .' (' . $comment->getPostedBy()->getUsername() . ')'; ?> *
+* <?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getNameWithUsername())); ?> *
 <?php echo $comment->getContent(); ?>
 
 

--- a/modules/mailing/templates/_articleupdate.html.inc.php
+++ b/modules/mailing/templates/_articleupdate.html.inc.php
@@ -1,6 +1,6 @@
 <?php if ($article instanceof \thebuggenie\modules\publish\entities\Article): ?>
     <h3><?php echo __('%article updated', array('%article' => $article->getTitle())); ?></h3>
-    <h4><?php echo __('The article has been updated by %name', array('%name' => $user->getBuddyname())) .' ( ' . $user->getUsername() . '):'; ?></h4>
+    <h4><?php echo __('The article has been updated by %name', array('%name' => $user->getNameWithUsername())); ?></h4>
     <?php if (trim($change_reason) != ''): ?>
         <pre><?php echo $change_reason; ?></pre><br>
     <?php else: ?>

--- a/modules/mailing/templates/_articleupdate.text.inc.php
+++ b/modules/mailing/templates/_articleupdate.text.inc.php
@@ -1,6 +1,6 @@
 * <?php echo __('%article updated', array('%article' => $article->getTitle())); ?> *
 
-<?php echo __('The article has been updated by %name', array('%name' => $user->getBuddyname())) .' (' . $user->getUsername() . '):'; ?>
+<?php echo __('The article has been updated by %name', array('%name' => $user->getNameWithUsername())); ?>
 
 <?php echo (trim($change_reason) != '') ? '"'.$change_reason.'"' : '(' . __('No change reason provided') .')'; echo "\n"; ?>
 

--- a/modules/mailing/templates/_issuecomment.html.inc.php
+++ b/modules/mailing/templates/_issuecomment.html.inc.php
@@ -1,10 +1,10 @@
 <?php if ($issue instanceof \thebuggenie\core\entities\Issue && $comment instanceof \thebuggenie\core\entities\Comment): ?>
     <h3>
         <?php echo $issue->getFormattedTitle(true); ?><br>
-        <span style="font-size: 0.8em; font-weight: normal;"><?php echo __('Created by %name', array('%name' => $issue->getPostedBy()->getBuddyname())) . ' (' . $issue->getPostedBy()->getUsername() . ')'; ?></span>
+        <span style="font-size: 0.8em; font-weight: normal;"><?php echo __('Created by %name', array('%name' => $issue->getPostedBy()->getNameWithUsername())); ?></span>
     </h3>
     <br>
-    <h4><?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getBuddyname())) . ' ' . $comment->getPostedBy()->getUsername() . ')';?></h4>
+    <h4><?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getNameWithUsername()));?></h4>
     <p><?php echo $comment->getParsedContent(); ?></p>
     <br>
     <div style="color: #888;">

--- a/modules/mailing/templates/_issuecomment.text.inc.php
+++ b/modules/mailing/templates/_issuecomment.text.inc.php
@@ -1,8 +1,8 @@
 * <?php echo $issue->getFormattedTitle(true); ?> *
-<?php echo __('Created by %name', array('%name' =>  $issue->getPostedBy()->getBuddyname())) . ' (' . $issue->getPostedBy()->getUsername() . ')'; ?>
+<?php echo __('Created by %name', array('%name' =>  $issue->getPostedBy()->getNameWithUsername())); ?>
 
 
-* <?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getBuddyname())) . ' (' . $comment->getPostedBy()->getUsername() . ')'; ?> *
+* <?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getNameWithUsername())); ?> *
 <?php echo $comment->getContent(); ?>
 
 

--- a/modules/mailing/templates/_issuecreate.html.inc.php
+++ b/modules/mailing/templates/_issuecreate.html.inc.php
@@ -1,7 +1,7 @@
 <?php if ($issue instanceof \thebuggenie\core\entities\Issue): ?>
     <h3>
         <?php echo $issue->getFormattedTitle(true); ?><br>
-        <span style="font-size: 0.8em; font-weight: normal;"><?php echo __('Created by %name', array('%name' =>  $issue->getPostedBy()->getBuddyname())) . ' (' . $issue->getPostedBy()->getUsername() . ')'; ?></span>
+        <span style="font-size: 0.8em; font-weight: normal;"><?php echo __('Created by %name', array('%name' =>  $issue->getPostedBy()->getNameWithUsername())); ?></span>
     </h3>
     <br>
     <h4><?php echo __('Description:');?></h4>

--- a/modules/mailing/templates/_issuecreate.text.inc.php
+++ b/modules/mailing/templates/_issuecreate.text.inc.php
@@ -1,5 +1,5 @@
 * <?php echo $issue->getFormattedTitle(true); ?> *
-<?php echo __('Created by %name', array('%name' =>  $issue->getPostedBy()->getBuddyname())) . ' (' . $issue->getPostedBy()->getUsername() . ')'; ?>
+<?php echo __('Created by %name', array('%name' =>  $issue->getPostedBy()->getNameWithUsername())); ?>
 
 
 * <?php echo __('Description') . ':'; ?> *

--- a/modules/mailing/templates/_issuesubscribed.html.inc.php
+++ b/modules/mailing/templates/_issuesubscribed.html.inc.php
@@ -1,7 +1,7 @@
 <?php if ($issue instanceof \thebuggenie\core\entities\Issue): ?>
     <h3>
         <?php echo $issue->getFormattedTitle(true); ?><br>
-        <span style="font-size: 0.8em; font-weight: normal;">Created by <?php echo $issue->getPostedBy()->getBuddyname(); ?> (<?php echo $issue->getPostedBy()->getUsername(); ?>)</span>
+        <span style="font-size: 0.8em; font-weight: normal;">Created by <?php echo $issue->getPostedBy()->getNameWithUsername(); ?></span>
     </h3>
     You have been subscribed to this issue and will be notified if and when it changes in the future.<br>
     To unsubscribe from this issue, open the issue in your web browser and click the "star" icon in the top left corner, next to the issue title.

--- a/modules/mailing/templates/_issuesubscribed.text.inc.php
+++ b/modules/mailing/templates/_issuesubscribed.text.inc.php
@@ -1,5 +1,5 @@
 * <?php echo $issue->getFormattedTitle(true); ?> *
-Created by <?php echo $issue->getPostedBy()->getBuddyname(); ?> (<?php echo $issue->getPostedBy()->getUsername(); ?>)
+Created by <?php echo $issue->getPostedBy()->getNameWithUsername(); ?>
 
 You have been subscribed to this issue and will be notified if and when it changes in the future.
 To unsubscribe from this issue, open the issue in your web browser and click the "star" icon in the top left corner, next to the issue title.

--- a/modules/mailing/templates/_issueupdate.html.inc.php
+++ b/modules/mailing/templates/_issueupdate.html.inc.php
@@ -1,11 +1,11 @@
 <?php if ($issue instanceof \thebuggenie\core\entities\Issue): ?>
     <h3>
         <?php echo $issue->getFormattedTitle(true); ?><br>
-        <span style="font-size: 0.8em; font-weight: normal;"><?php echo __('Updated by %name', array('%name' => $updated_by->getBuddyname())) . ' (' . $updated_by->getUsername() . ')'; ?></span><br>
-        <span style="font-size: 0.8em; color: #AAA; font-weight: normal;"><?php echo __('Created by %name', array('%name' => $issue->getPostedBy()->getBuddyname())) . ' (' . $issue->getPostedBy()->getUsername() . ')'; ?></span>
+        <span style="font-size: 0.8em; font-weight: normal;"><?php echo __('Updated by %name', array('%name' => $updated_by->getNameWithUsername())); ?></span><br>
+        <span style="font-size: 0.8em; color: #AAA; font-weight: normal;"><?php echo __('Created by %name', array('%name' => $issue->getPostedBy()->getNameWithUsername())); ?></span>
     </h3>
     <?php if (isset($comment) && $comment instanceof \thebuggenie\core\entities\Comment): ?>
-        <h4><?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getBuddyname())) . ' (' . $comment->getPostedBy()->getUsername() . ')'; ?></h4>
+        <h4><?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getNameWithUsername())); ?></h4>
         <p><?php echo $comment->getParsedContent(); ?></p>
         <br>
     <?php endif; ?>

--- a/modules/mailing/templates/_issueupdate.text.inc.php
+++ b/modules/mailing/templates/_issueupdate.text.inc.php
@@ -1,10 +1,10 @@
 * <?php echo $issue->getFormattedTitle(true); ?> *
-<?php echo __('Updated by %name', array('%name' => $updated_by->getBuddyname())) . ' (' . $updated_by->getUsername() . ')';?>
+<?php echo __('Updated by %name', array('%name' => $updated_by->getNameWithUsername()));?>
 
-<?php echo '(' . __('Created by %name', array('%name' => $issue->getPostedBy()->getBuddyname())) . ' / ' . $issue->getPostedBy()->getUsername() . ')'; ?>
+<?php echo '(' . __('Created by %name', array('%name' => $issue->getPostedBy()->getNameWithUsername())); ?>
 
 <?php if (isset($comment) && $comment instanceof \thebuggenie\core\entities\Comment): ?>
-* <?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getBuddyname())) . ' (' . $comment->getPostedBy()->getUsername() . ')';?> *
+* <?php echo __('Comment by %name', array('%name' => $comment->getPostedBy()->getNameWithUsername()));?> *
 <?php echo $comment->getContent(); ?>
 <?php endif; ?>
 


### PR DESCRIPTION
Added support to configure display name formatting for users.

Settings->Users & Security->User's display name format.

It allows two configurations:
- Prefer buddy (default -- current functionality)
- Prefer real name

Change affects Issue/project view where users are listed and also to emails.