### PR TITLE
Fix reporting of time spent for hour units.

### DIFF
--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -4965,7 +4965,7 @@
                                     $old_time = array('months' => $this->getChangedPropertyOriginal('_spent_months'),
                                                         'weeks' => $this->getChangedPropertyOriginal('_spent_weeks'),
                                                         'days' => $this->getChangedPropertyOriginal('_spent_days'),
-                                                        'hours' => $this->getChangedPropertyOriginal('_spent_hours'),
+                                                        'hours' => round($this->getChangedPropertyOriginal('_spent_hours') / 100, 2),
                                                         'points' => $this->getChangedPropertyOriginal('_spent_points'));
 
                                     $old_formatted_time = (array_sum($old_time) > 0) ? Issue::getFormattedTime($old_time) : framework\Context::getI18n()->__('No time spent');

--- a/core/modules/main/templates/_issuespenttime.inc.php
+++ b/core/modules/main/templates/_issuespenttime.inc.php
@@ -13,7 +13,7 @@
                     </select>
                     <select id="issue_timespent_<?php echo $entry->getID(); ?>_month" name="edited_at[month]">
                         <?php for($cc = 1; $cc <= 12; $cc++): ?>
-                            <option value="<?php echo $cc-1; ?>"<?php if ($cc == date('m', $entry->getEditedAt())): ?> selected<?php endif; ?>><?php echo date('F', mktime(12, 0, 1, $cc, 1)); ?></option>
+                            <option value="<?php echo $cc; ?>"<?php if ($cc == date('m', $entry->getEditedAt())): ?> selected<?php endif; ?>><?php echo date('F', mktime(12, 0, 1, $cc, 1)); ?></option>
                         <?php endfor; ?>
                     </select>
                     <select id="issue_timespent_<?php echo $entry->getID(); ?>_year" name="edited_at[year]">

--- a/core/modules/main/templates/_issuespenttime.inc.php
+++ b/core/modules/main/templates/_issuespenttime.inc.php
@@ -24,7 +24,7 @@
                 </li>
                 <li>
                     <label for="issue_timespent_<?php echo $entry->getID(); ?>_activitytype"><?php echo __('Activity'); ?></label>
-                    <select id="issue_timespent_<?php echo $entry->getID(); ?>_activitytype" name="activitytype">
+                    <select id="issue_timespent_<?php echo $entry->getID(); ?>_activitytype" name="timespent_activitytype">
                         <?php foreach (\thebuggenie\core\entities\ActivityType::getAll() as $activitytype): ?>
                             <option value="<?php echo $activitytype->getID(); ?>" <?php if ($activitytype->getID() == $entry->getActivityTypeID()) echo 'selected'; ?>><?php echo $activitytype->getName(); ?></option>
                         <?php endforeach; ?>
@@ -52,7 +52,7 @@
                 </li>
                 <li>
                     <label for="issue_timespent_<?php echo $entry->getID(); ?>_comment" class="optional"><?php echo __('Comment (optional)'); ?></label>
-                    <input id="issue_timespent_<?php echo $entry->getID(); ?>_comment" name="comment" type="text" style="width: 500px;" value="<?php echo htmlentities($entry->getComment(), ENT_COMPAT, \thebuggenie\core\framework\Context::getI18n()->getCharset()); ?>">
+                    <input id="issue_timespent_<?php echo $entry->getID(); ?>_comment" name="timespent_comment" type="text" style="width: 500px;" value="<?php echo htmlentities($entry->getComment(), ENT_COMPAT, \thebuggenie\core\framework\Context::getI18n()->getCharset()); ?>">
                 </li>
                 <li style="text-align: right;">
                     <input type="submit" class="button button-silver" value="<?php echo __('Update entry'); ?>">


### PR DESCRIPTION
When time spent is logged hours are logged with multiplier of 100. It needs to
be taken into account when logging amount of hours previously the issue had.

This fixes email reporting of issue changes when hours are added for the task.

Added fixes for editing time spent's "Time logged at"'s month value, comments and activity type.

Signed-off-by: Vesa Jääskeläinen <dachaac@gmail.com>