### PR TITLE
Fix reporting of time spent for hour units.

### DIFF
--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -4965,7 +4965,7 @@
                                     $old_time = array('months' => $this->getChangedPropertyOriginal('_spent_months'),
                                                         'weeks' => $this->getChangedPropertyOriginal('_spent_weeks'),
                                                         'days' => $this->getChangedPropertyOriginal('_spent_days'),
-                                                        'hours' => $this->getChangedPropertyOriginal('_spent_hours'),
+                                                        'hours' => round($this->getChangedPropertyOriginal('_spent_hours') / 100, 2),
                                                         'points' => $this->getChangedPropertyOriginal('_spent_points'));
 
                                     $old_formatted_time = (array_sum($old_time) > 0) ? Issue::getFormattedTime($old_time) : framework\Context::getI18n()->__('No time spent');


### PR DESCRIPTION
When time spent is logged hours are logged with multiplier of 100. It needs to
be taken into account when logging amount of hours previously the issue had.

This fixes email reporting of issue changes when hours are added for the task.

Signed-off-by: Vesa Jääskeläinen <dachaac@gmail.com>