### PR TITLE
Quotes are required around the DB password

### DIFF
--- a/core/config/b2db.sample.yml
+++ b/core/config/b2db.sample.yml
@@ -1,6 +1,6 @@
 b2db:
-    username: <username>
-    password: <password>
+    username: "<username>"
+    password: "<password>"
     dsn: "<dbtype>:host=<hostname>;dbname=<dbname>"
     tableprefix: '<prefix>'
     cacheclass: '\thebuggenie\core\framework\Cache'


### PR DESCRIPTION
Without quotes, upgrades will fail when people are using complex passwords.