### PR TITLE
Improve timezone selection list

### DIFF
--- a/core/framework/I18n.php
+++ b/core/framework/I18n.php
@@ -37,54 +37,22 @@
 
         public static function getTimezones()
         {
-            $list = DateTimeZone::listAbbreviations();
-            $idents = DateTimeZone::listIdentifiers();
-
-            $data = $offset = $added = array();
-            foreach ($list as $info)
+            $offsets = $options = array();
+            $now = new DateTime();
+            foreach (DateTimeZone::listIdentifiers() as $tz)
             {
-                foreach ($info as $zone)
-                {
-                    if (!empty($zone['timezone_id'])
-                            AND
-                            !in_array($zone['timezone_id'], $added)
-                            AND
-                            in_array($zone['timezone_id'], $idents))
-                    {
-                        $z = new DateTimeZone($zone['timezone_id']);
-                        $c = new DateTime(null, $z);
-                        $zone['time'] = $c->format('H:i a');
-                        $data[] = $zone;
-                        $offset[] = $z->getOffset($c);
-                        $added[] = $zone['timezone_id'];
-                    }
-                }
+                $now->setTimezone(new DateTimeZone($tz));
+                $offsets[] = $offset = $now->getOffset();
+                $hours = intval($offset / 3600);
+                $minutes = abs(intval($offset % 3600 / 60));
+                $hm = $offset ? sprintf('%+03d:%02d', $hours, $minutes) : '';
+                $name = str_replace('_', ' ', $tz);
+                $name = str_replace('St ', 'St. ', $tz);
+                $options[$tz] = "GMT$hm $name";
             }
 
-            array_multisort($offset, SORT_ASC, $data);
-            $options = array();
-            foreach ($data as $row)
-            {
-                $options[$row['timezone_id']] = self::formatOffset($row['offset']) . ' ('.$row['timezone_id'].')';
-            }
-
+            array_multisort($offsets, $options);
             return $options;
-        }
-
-        protected static function formatOffset($offset)
-        {
-            $hours = $offset / 3600;
-            $remainder = $offset % 3600;
-            $sign = $hours > 0 ? '+' : '-';
-            $hour = (int) abs($hours);
-            $minutes = (int) abs($remainder / 60);
-
-            if ($hour == 0 AND $minutes == 0)
-            {
-                $sign = ' ';
-            }
-            return 'GMT' . $sign . str_pad($hour, 2, '0', STR_PAD_LEFT)
-                    . ':' . str_pad($minutes, 2, '0');
         }
 
         public function __construct($language)


### PR DESCRIPTION
I noticed that some timezones were displayed incorrectly in the TBG timezone drop down list. The code currently does this: 

```php
foreach ($info as $zone)
{
    if (!empty($zone['timezone_id'])
        AND
        !in_array($zone['timezone_id'], $added)
        AND
        in_array($zone['timezone_id'], $idents))
    {
        $z = new DateTimeZone($zone['timezone_id']);
        $c = new DateTime(null, $z);
        $zone['time'] = $c->format('H:i a');
        $data[] = $zone;
        $offset[] = $z->getOffset($c);
        $added[] = $zone['timezone_id'];
    }
}
```
There may be multiple zones matching a particular timezone_id, to account for historical changes to daylight savings periods etc. The existing code accounts for that using the $added[] array so that each timezone_id is processed only once. The correct zone associated with the current time is determined by constructing a new DateTimeZone into $z based on the timezone_id. The offset is then calculated from that zone using $z->getOffset() and added to the $offset[] array.

However, the zone added to the $data[] array, and subsequently used for the display, is whichever zone was first enumerated for the corresponding timezone_id, and may not be the correct one for the current time.

In addition, since a DateTimeZone object is being constructed anyway, it is simpler to iterate through the timezone identifiers rather than the zones.

I have adapted the code from the following stack overflow answer:

http://stackoverflow.com/questions/1727077/generating-a-drop-down-list-of-timezones-with-php/21211073#21211073