### PR TITLE
Correct the calculation of Today, Yesterday, Tomorrow for timezone

### DIFF
--- a/core/lib/common.inc.php
+++ b/core/lib/common.inc.php
@@ -78,6 +78,13 @@
         return $randomNumber;
     }
 
+    function day_delta($tstamp, $tzoffset)
+    {
+        $mdy = explode(':', date('m:d:Y', time() + $tzoffset));
+        $midnight = mktime(0, 0, 0, $mdy[0], $mdy[1], $mdy[2]);
+        return floor(($tstamp - $midnight) / 24 / 60 / 60);
+    }
+
     /**
      * Returns a formatted string of the given timestamp
      *
@@ -88,10 +95,12 @@
      */
     function tbg_formatTime($tstamp, $format = 0, $skipusertimestamp = false, $skiptimestamp = false)
     {
+        $tzoffset = 0;
         // offset the timestamp properly
         if (!$skiptimestamp)
         {
-            $tstamp += tbg_get_timezone_offset($skipusertimestamp);
+            $tzoffset = tbg_get_timezone_offset($skipusertimestamp);
+            $tstamp += $tzoffset;
         }
 
         switch ($format)
@@ -131,15 +140,16 @@
                 break;
             case 12:
                 $tstring = '';
-                if (date('dmY', $tstamp) == date('dmY'))
+                $days = day_delta($tstamp, $tzoffset);
+                if ($days == 0)
                 {
                     $tstring .= __('Today') . ', ';
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') - 1))))
+                elseif ($days == -1)
                 {
                     $tstring .= __('Yesterday') . ', ';
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') + 1))))
+                elseif ($days == 1)
                 {
                     $tstring .= __('Tomorrow') . ', ';
                 }
@@ -151,15 +161,16 @@
                 break;
             case 13:
                 $tstring = '';
-                if (date('dmY', $tstamp) == date('dmY'))
+                $days = day_delta($tstamp, $tzoffset);
+                if ($days == 0)
                 {
                     //$tstring .= __('Today') . ', ';
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') - 1))))
+                elseif ($days == -1)
                 {
                     $tstring .= __('Yesterday') . ', ';
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') + 1))))
+                elseif ($days == 1)
                 {
                     $tstring .= __('Tomorrow') . ', ';
                 }
@@ -171,15 +182,16 @@
                 break;
             case 14:
                 $tstring = '';
-                if (date('dmY', $tstamp) == date('dmY'))
+                $days = day_delta($tstamp, $tzoffset);
+                if ($days == 0)
                 {
                     $tstring .= __('Today');
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') - 1))))
+                elseif ($days == -1)
                 {
                     $tstring .= __('Yesterday');
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') + 1))))
+                elseif ($days == 1)
                 {
                     $tstring .= __('Tomorrow');
                 }
@@ -205,15 +217,16 @@
                 break;
             case 20:
                 $tstring = '';
-                if (date('dmY', $tstamp) == date('dmY'))
+                $days = day_delta($tstamp, $tzoffset);
+                if ($days == 0)
                 {
                     $tstring .= __('Today') . ' (' . strftime('%H:%M', $tstamp) . ')';
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') - 1))))
+                elseif ($days == -1)
                 {
                     $tstring .= __('Yesterday') . ' (' . strftime('%H:%M', $tstamp) . ')';
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') + 1))))
+                elseif ($days == 1)
                 {
                     $tstring .= __('Tomorrow') . ' (' . strftime('%H:%M', $tstamp) . ')';
                 }
@@ -277,15 +290,16 @@
                 break;
             case 23:
                 $tstring = '';
-                if (date('dmY', $tstamp) == date('dmY'))
+                $days = day_delta($tstamp, $tzoffset);
+                if ($days == 0)
                 {
                     $tstring .= __('Today');
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') - 1))))
+                elseif ($days == -1)
                 {
                     $tstring .= __('Yesterday');
                 }
-                elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') + 1))))
+                elseif ($days == 1)
                 {
                     $tstring .= __('Tomorrow');
                 }


### PR DESCRIPTION
When tbg_formatTime() attempts to display recent days as Yesterday, Today or Tomorrow it uses the following approach:

```php
$tstamp += tbg_get_timezone_offset();
if (date('dmY', $tstamp) == date('dmY'))
{
    $tstring .= __('Today') . ', ';
}
elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') - 1))))
{
    $tstring .= __('Yesterday') . ', ';
}
elseif (date('dmY', $tstamp) == date('dmY', mktime(0, 0, 0, date('m'), (date('d') + 1))))
{
    $tstring .= __('Tomorrow') . ', ';
}
```

$tstamp is corrected for the desired timezone and then 'dmY' is calculated for $tstamp and compared against the current 'dmY'. However the current 'dmY' is not timezone corrected.

In some cases this results in the wrong day being displayed. For example, let $tstamp = 2015-06-18T20:00Z and assume it is now 2015-06-18T22:00Z, so the event occurred two hours ago. For a user who has selected +08:00 timezone, $tstamp = 2015-06-19T04:00+08:00 so date('d', $tstamp) = 19 but date('d') = 18 (since it is not timezone corrected) and this event will be displayed as occurring tomorrow, even though it occurred earlier today.

To keep the code simple a function can be used to calculate the number of 24 hour periods since (or to) the timezone corrected midnight of the current day:

```php
function day_delta($tstamp, $tzoffset)
{
    $mdy = explode(':', date('m:d:Y', time() + $tzoffset));
    $midnight = mktime(0, 0, 0, $mdy[0], $mdy[1], $mdy[2]);
    return floor(($tstamp - $midnight) / 24 / 60 / 60);
}
```

This requires only a single call to date() and mktime() and reduces the check for Yesterday, Today and Tomorrow to simple integer comparison:

```php
if ($days == 0)
{
    $tstring .= __('Today') . ', ';
}
elseif ($days == -1)
{
    $tstring .= __('Yesterday') . ', ';
}
elseif ($days == 1)
{
    $tstring .= __('Tomorrow') . ', ';
}
```