### PR TITLE
Fix jump to an issue

### DIFF
--- a/core/modules/search/Actions.php
+++ b/core/modules/search/Actions.php
@@ -196,7 +196,7 @@
                 else
                 {
                     $issues = $this->issues;
-                    $issue = array_shift($issues);
+                    $issue = is_array($issues) ? array_shift($issues) : null;
                     if ($issue instanceof entities\Issue)
                     {
                         return $this->forward($this->getRouting()->generate('viewissue', array('project_key' => $issue->getProject()->getKey(), 'issue_no' => $issue->getFormattedIssueNo())));


### PR DESCRIPTION
This commit resolves the following error that occurs when using the "Jump to an Issue" for a project listed on the front page:

```
array_shift() expects parameter 1 to be array, null given

The following error occured:
array_shift() expects parameter 1 to be array, null given in /thebuggenie/core/modules/search/Actions.php, line 199 
```