### PR TITLE
Fix bug when variable "$colour" is empty string.

### DIFF
--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -2860,6 +2860,8 @@
 
             $rgb = hex2rgb($this->_scrumcolor);
 
+            if (! $rgb) return '#333';
+
             return 0.299*$rgb['red'] + 0.587*$rgb['green'] + 0.114*$rgb['blue'] > 170 ? '#333' : '#FFF';
         }
 

--- a/core/entities/Status.php
+++ b/core/entities/Status.php
@@ -59,6 +59,8 @@
 
             $rgb = hex2rgb($this->_itemdata);
 
+            if (! $rgb) return '#333';
+
             return 0.299*$rgb['red'] + 0.587*$rgb['green'] + 0.114*$rgb['blue'] > 170 ? '#333' : '#FFF';
         }
         

--- a/core/lib/ui.inc.php
+++ b/core/lib/ui.inc.php
@@ -303,7 +303,7 @@
      * @return array
      */
     function hex2rgb($colour) {
-        if ($colour[0] == '#')
+        if (strlen($colour) > 0 && $colour[0] == '#')
         {
             $colour = substr($colour, 1);
         }


### PR DESCRIPTION
Function "hex2rgb" Introduced in ab4bee79af635a2466556217d9947656673f3beb didn't account for empty variable "$colour". 

Credits to @dachaac for spotting it and proposing this solution. :)