### PR TITLE
Fix the deadend pages list and orphaned pages list

### DIFF
--- a/modules/publish/entities/tables/ArticleLinks.php
+++ b/modules/publish/entities/tables/ArticleLinks.php
@@ -65,26 +65,6 @@
         public function getUniqueArticleNames()
         {
             $crit = $this->getCriteria();
-            $crit->addSelectionColumn(self::LINK_ARTICLE_NAME);
-            $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
-            $crit->setDistinct();
-
-            $names = array();
-            if ($res = $this->doSelect($crit))
-            {
-                while ($row = $res->getNextRow())
-                {
-                    $article_name = $row->get(self::LINK_ARTICLE_NAME);
-                    $names[$article_name] = $article_name;
-                }
-            }
-
-            return $names;
-        }
-
-        public function getUniqueLinkedArticleNames()
-        {
-            $crit = $this->getCriteria();
             $crit->addSelectionColumn(self::ARTICLE_NAME);
             $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
             $crit->setDistinct();
@@ -95,6 +75,26 @@
                 while ($row = $res->getNextRow())
                 {
                     $article_name = $row->get(self::ARTICLE_NAME);
+                    $names[$article_name] = $article_name;
+                }
+            }
+
+            return $names;
+        }
+
+        public function getUniqueLinkedArticleNames()
+        {
+            $crit = $this->getCriteria();
+            $crit->addSelectionColumn(self::LINK_ARTICLE_NAME);
+            $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
+            $crit->setDistinct();
+
+            $names = array();
+            if ($res = $this->doSelect($crit))
+            {
+                while ($row = $res->getNextRow())
+                {
+                    $article_name = $row->get(self::LINK_ARTICLE_NAME);
                     $names[$article_name] = $article_name;
                 }
             }

--- a/modules/publish/templates/_specialdeadendpages.inc.php
+++ b/modules/publish/templates/_specialdeadendpages.inc.php
@@ -6,7 +6,7 @@
         </div>
     <?php endif; ?>
     <p>
-        <?php echo __('Below is a listing of all pages that has no links to other pages.'); ?>
+        <?php echo __('Below is a listing of pages that have no links to other pages.'); ?>
     </p>
     <?php include_component('publish/articleslist', array('articles' => $articles, 'include_redirects' => false)); ?>
 </div>


### PR DESCRIPTION
The wiki dead end and orphaned special page are interchanged - the dead end list displays orphaned pages and vice-versa.