### PR TITLE
Fix integer detection for vcs commit revision

### DIFF
--- a/modules/vcs_integration/Actions.php
+++ b/modules/vcs_integration/Actions.php
@@ -100,7 +100,7 @@
             }
 
             // Obtain previous revision
-            if (!framework\Context::getRequest()->hasParameter('oldrev') && !is_integer($new_rev))
+            if (!framework\Context::getRequest()->hasParameter('oldrev') && !ctype_digit($new_rev))
             {
                 echo 'Error: If only the new revision is specified, it must be a number so that old revision can be calculated from it (by substracting 1 from new revision number).';
                 exit;

--- a/modules/vcs_integration/cli/Report.php
+++ b/modules/vcs_integration/cli/Report.php
@@ -68,7 +68,7 @@
                 exit;
             }
 
-            if ($old_rev === null && !is_integer($new_rev))
+            if ($old_rev === null && !ctype_digit($new_rev))
             {
                 $this->cliEcho("Error: if only the new revision is specified, it must be a number so that old revision can be calculated from it (by substracting 1 from new revision number).");
             }


### PR DESCRIPTION
The vcs-integration module supports specifying a single revision when reporting a commit providing the new revision is an integer. However the integer detection does not work because is_integer() tests the _type_ of the variable rather than the content and always reports false for a string.

> To test if a variable is a number or a numeric string (such as form input, which is always a string), you must use is_numeric().

http://php.net/manual/en/function.is-int.php

Rather than use is_numeric() as recommended by the PHP manual, which would also return true for a non-integer numeric, ctype_digit() is a simple alternative that will check a string for pure integer content.

> Returns TRUE if every character in the string text is a decimal digit, FALSE otherwise.

http://php.net/manual/en/function.ctype-digit.php