### PR TITLE
Do not urldecode() request parameters since PHP has already decoded them

### DIFF
--- a/core/framework/Routing.php
+++ b/core/framework/Routing.php
@@ -525,7 +525,7 @@
                     {
                         if (preg_match('#[a-z_\-]#i', $name))
                         {
-                            $out[$name] = urldecode($value);
+                            $out[$name] = $value;
                         }
                         else
                         {
@@ -539,7 +539,7 @@
                         // if $found is a named url element (i.e. ':action')
                         if (isset($names[$pos]))
                         {
-                            $out[$names[$pos]] = urldecode($found);
+                            $out[$names[$pos]] = $found;
                         }
                         // unnamed elements go in as 'pass'
                         else

--- a/core/modules/main/Actions.php
+++ b/core/modules/main/Actions.php
@@ -2923,8 +2923,8 @@
             elseif (array_key_exists('file_id', $status) && $request['mode'] == 'article')
             {
                 $file = entities\File::getB2DBTable()->selectById($status['file_id']);
-                $status['content_uploader'] = $this->getComponentHTML('main/attachedfile', array('base_id' => 'article_' . mb_strtolower(urldecode($request['article_name'])) . '_files', 'mode' => 'article', 'article_name' => $request['article_name'], 'file' => $file));
-                $status['content_inline'] = $this->getComponentHTML('main/attachedfile', array('base_id' => 'article_' . mb_strtolower(urldecode($request['article_name'])) . '_files', 'mode' => 'article', 'article_name' => $request['article_name'], 'file' => $file));
+                $status['content_uploader'] = $this->getComponentHTML('main/attachedfile', array('base_id' => 'article_' . mb_strtolower($request['article_name']) . '_files', 'mode' => 'article', 'article_name' => $request['article_name'], 'file' => $file));
+                $status['content_inline'] = $this->getComponentHTML('main/attachedfile', array('base_id' => 'article_' . mb_strtolower($request['article_name']) . '_files', 'mode' => 'article', 'article_name' => $request['article_name'], 'file' => $file));
                 $article = \thebuggenie\modules\publish\entities\Article::getByName($request['article_name']);
                 $status['attachmentcount'] = count($article->getFiles());
             }

--- a/modules/vcs_integration/Actions.php
+++ b/modules/vcs_integration/Actions.php
@@ -64,15 +64,15 @@
 
             /* Prepare variables */
             $passkey = framework\Context::getRequest()->getParameter('passkey');
-            $project_id = urldecode(framework\Context::getRequest()->getParameter('project_id'));
-            $author = trim(html_entity_decode(urldecode(framework\Context::getRequest()->getParameter('author')), ENT_QUOTES), '"');
+            $project_id = framework\Context::getRequest()->getParameter('project_id');
+            $author = trim(html_entity_decode(framework\Context::getRequest()->getParameter('author'), ENT_QUOTES), '"');
             $new_rev = framework\Context::getRequest()->getParameter('rev');
-            $commit_msg = trim(html_entity_decode(urldecode(framework\Context::getRequest()->getParameter('commit_msg')), ENT_QUOTES), '"');
-            $changed = trim(html_entity_decode(urldecode(framework\Context::getRequest()->getParameter('changed')), ENT_QUOTES), '"');
+            $commit_msg = trim(html_entity_decode(framework\Context::getRequest()->getParameter('commit_msg'), ENT_QUOTES), '"');
+            $changed = trim(html_entity_decode(framework\Context::getRequest()->getParameter('changed'), ENT_QUOTES), '"');
 
             if (framework\Context::getRequest()->hasParameter('branch'))
             {
-                $branch = trim(html_entity_decode(urldecode(framework\Context::getRequest()->getParameter('branch')), ENT_QUOTES), '"');
+                $branch = trim(html_entity_decode(framework\Context::getRequest()->getParameter('branch'), ENT_QUOTES), '"');
             }
             else
             {
@@ -142,7 +142,7 @@
             framework\Context::getResponse()->renderHeaders();
 
             $passkey = framework\Context::getRequest()->getParameter('passkey');
-            $project_id = urldecode(framework\Context::getRequest()->getParameter('project_id'));
+            $project_id = framework\Context::getRequest()->getParameter('project_id');
 
             try
             {
@@ -282,7 +282,7 @@
             framework\Context::getResponse()->renderHeaders();
 
             $passkey = framework\Context::getRequest()->getParameter('passkey');
-            $project_id = urldecode(framework\Context::getRequest()->getParameter('project_id'));
+            $project_id = framework\Context::getRequest()->getParameter('project_id');
 
             try
             {
@@ -356,7 +356,7 @@
             framework\Context::getResponse()->renderHeaders();
 
             $passkey = framework\Context::getRequest()->getParameter('passkey');
-            $project_id = urldecode(framework\Context::getRequest()->getParameter('project_id'));
+            $project_id = framework\Context::getRequest()->getParameter('project_id');
             $project = Project::getB2DBTable()->selectByID($project_id);
 
             // Validate access


### PR DESCRIPTION
The core\framework\Request object populates the request parameters from `$_GET` and `$_POST`:

```php
            foreach ($_POST as $key => $value)
            {
                $this->_post_parameters[$key] = $value;
                $this->_request_parameters[$key] = $value;
            }
            foreach ($_GET as $key => $value)
            {
                $this->_get_parameters[$key] = $value;
                $this->_request_parameters[$key] = $value;
            }
```

This data is already decoded and does not require additional `urldecode()`:

> Warning
The superglobals `$_GET` and `$_REQUEST` are already decoded. Using `urldecode()` on an element in `$_GET` or `$_REQUEST` could have unexpected and dangerous results.

http://php.net/manual/en/function.urldecode.php

The warning does not explicitly mention `$_POST`, and I haven't found any explicit documentation indicating that `$_POST` data is already decoded, but testing confirms that it is (also http://stackoverflow.com/a/3384180). Besides, POST data may not even be url encoded (e.g it may use multipart/form-data instead) which is why it makes sense for PHP to pre-decode this data.

As an example of where this is significant, when reporting a commit via the vcs_integration module the double-decoding requires the data to be double-encoded in order to be properly decoded. For example, the commit message `Added missing i++` must be double-encoded as `Added missing i%252B%252B` instead of `Added missing i%2B%2B`.