### PR TITLE
Improve precision of special char parsing

### DIFF
--- a/core/helpers/TextParser.php
+++ b/core/helpers/TextParser.php
@@ -1038,7 +1038,7 @@
             $char_regexes[] = array(self::getIssueRegex(), array($this, '_parse_issuelink'));
             $char_regexes[] = array('/\B\@([\w\-]+)/i', array($this, '_parse_mention'));
             $char_regexes[] = array('/(?<=\s|^)(\:\(|\:-\(|\:\)|\:-\)|8\)|8-\)|B\)|B-\)|\:-\/|\:-D|\:-P|\(\!\)|\(\?\))(?=\s|$)/', array($this, '_getsmiley'));
-            $char_regexes[] = array('/\&amp\;(.*)\;/i', array($this, '_parse_specialchar'));
+            $char_regexes[] = array('/&amp;([A-Za-z0-9]+|\#[0-9]+|\#[xX][0-9A-Fa-f^?]+);/', array($this, '_parse_specialchar'));
 
             $this->stop = false;
             $this->stop_all = false;


### PR DESCRIPTION
The regular expression for parsing html entities contains a greedy `.*` that will match up to the last semicolon. For example, the sequence `&amp; &amp; &gt;` is treated as a single entity, with the result that the second `&amp;` and the `&gt;` are not detected as html entities.

The `CHAR_REFS_REGEX` regular expression from the mediawiki Sanitizer.php can be adapted to tame the greediness.

https://github.com/wikimedia/mediawiki/blob/master/includes/Sanitizer.php