### PR TITLE
fix permissions applied to parent namespaces of wiki articles

### DIFF
--- a/modules/publish/Publish.php
+++ b/modules/publish/Publish.php
@@ -425,9 +425,10 @@
                 foreach ($namespaces as $namespace)
                 {
                     $composite_ns .= ($composite_ns != '') ? ":{$namespace}" : $namespace;
-                    if ($user->hasPermission($permission_name, $composite_ns, 'publish'))
+                    $retval = $user->hasPermission($permission_name, $composite_ns, 'publish');
+                    if ($retval !== null)
                     {
-                        return true;
+                        return $retval;
                     }
                 }
             }


### PR DESCRIPTION
The permissions check applied to an article short-circuits if access is either explicitly granted or denied for that article. The permissions check for parent namespaces of an article only short-circuits if permission has been granted. For consistency, I believe this should follow the same model as the permissions check for the article itself so that denying access to a namespace denies access to all child articles, unless explicitly overridden on the child article.