### PR TITLE
Remove dodgy characters that snuck into the special chars regex

### DIFF
--- a/core/helpers/TextParser.php
+++ b/core/helpers/TextParser.php
@@ -1038,7 +1038,7 @@
             $char_regexes[] = array(self::getIssueRegex(), array($this, '_parse_issuelink'));
             $char_regexes[] = array('/\B\@([\w\-]+)/i', array($this, '_parse_mention'));
             $char_regexes[] = array('/(?<=\s|^)(\:\(|\:-\(|\:\)|\:-\)|8\)|8-\)|B\)|B-\)|\:-\/|\:-D|\:-P|\(\!\)|\(\?\))(?=\s|$)/', array($this, '_getsmiley'));
-            $char_regexes[] = array('/&amp;([A-Za-z0-9]+|\#[0-9]+|\#[xX][0-9A-Fa-f^?]+);/', array($this, '_parse_specialchar'));
+            $char_regexes[] = array('/&amp;([A-Za-z0-9]+|\#[0-9]+|\#[xX][0-9A-Fa-f]+);/', array($this, '_parse_specialchar'));
 
             $this->stop = false;
             $this->stop_all = false;


### PR DESCRIPTION
One of my previous PRs contained a couple of dodgy characters in the special chars regex. I'm sorry to increase your workload by having to submit an additional PR to fix my error.