### PR TITLE
Preliminary support for DB streaming

### DIFF
--- a/core/modules/main/Actions.php
+++ b/core/modules/main/Actions.php
@@ -3166,14 +3166,21 @@
                     $this->getResponse()->renderHeaders();
                     if (framework\Settings::getUploadStorage() == 'files')
                     {
-                        fpassthru(fopen(framework\Settings::getUploadsLocalpath() . $file->getRealFilename(), 'r'));
-                        exit();
+                        $fh = fopen(framework\Settings::getUploadsLocalpath() . $file->getRealFilename(), 'r');
                     }
                     else
                     {
-                        echo $file->getContent();
-                        exit();
+                        $fh = $file->getContent();
                     }
+                    if (is_resource($fh))
+                    {
+                        fpassthru($fh);
+                    }
+                    else
+                    {
+                        echo $fh;
+                    }
+                    exit();
                 }
             }
             $this->return404(framework\Context::getI18n()->__('This file does not exist'));


### PR DESCRIPTION
This is a preparatory commit to provide a code path to support streaming uploaded files (attachments etc) directly from the database. No immediate impact is anticipated. An additional companion b2db PR is required to activate this code path.

The driving motivation for this is to properly support storage of uploaded files within postgresql, which requires binary data to be escaped when inserted into a bytea column:
http://php.net/manual/en/function.pg-escape-bytea.php
If the data is not properly escaped an error similar to the following occurs when inserting the data:
> ERROR: invalid byte sequence for encoding "UTF8": 0x89

PHP's PDO provides built-in support for reading and writing binary data, and also supports streaming data from the database.
http://php.net/manual/en/pdo.lobs.php
http://www.it-iss.com/postgresql/postgresql-pdo-reading-and-writing-binary-content-to-the-database/

Further explanation will be provided on a future companion b2db PR.