### PR TITLE
Remove redundant HTML entity encoding from labels

### DIFF
--- a/core/modules/configuration/templates/configureuploads.html.php
+++ b/core/modules/configuration/templates/configureuploads.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->setTitle(__('Configure uploads &amp; attachments'));
+    $tbg_response->setTitle(__('Configure uploads & attachments'));
     
 ?>
 <script type="text/javascript">
@@ -34,7 +34,7 @@
         <?php include_component('leftmenu', array('selected_section' => \thebuggenie\core\framework\Settings::CONFIGURATION_SECTION_UPLOADS)); ?>
         <td valign="top" style="padding-left: 15px;">
             <div style="width: 730px;">
-                <h3><?php echo __('Configure uploads &amp; attachments'); ?></h3>
+                <h3><?php echo __('Configure uploads & attachments'); ?></h3>
                 <?php if ($uploads_enabled && $access_level == \thebuggenie\core\framework\Settings::ACCESS_FULL): ?>
                     <form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo make_url('configure_files'); ?>" method="post" onsubmit="TBG.Main.Helpers.formSubmit('<?php echo make_url('configure_files'); ?>', 'config_uploads'); return false;" id="config_uploads">
                 <?php endif; ?>

--- a/core/modules/configuration/templates/settings.html.php
+++ b/core/modules/configuration/templates/settings.html.php
@@ -20,8 +20,8 @@
                 <div style="margin-top: 15px; clear: both;" class="tab_menu inset">
                     <ul id="settings_menu">
                         <li class="selected" id="tab_general_settings"><a onclick="TBG.Main.Helpers.tabSwitcher('tab_general_settings', 'settings_menu');" href="javascript:void(0);"><?php echo image_tag('cfg_icon_general.png', array('style' => 'float: left;')).__('General', array(), true); ?></a></li>
-                        <li id="tab_reglang_settings"><a onclick="TBG.Main.Helpers.tabSwitcher('tab_reglang_settings', 'settings_menu');" href="javascript:void(0);"><?php echo image_tag('cfg_icon_reglang.png', array('style' => 'float: left;')).__('Regional &amp; language', array(), true); ?></a></li>
-                        <li id="tab_user_settings"><a onclick="TBG.Main.Helpers.tabSwitcher('tab_user_settings', 'settings_menu');" href="javascript:void(0);"><?php echo image_tag('cfg_icon_security.png', array('style' => 'float: left;')).__('Users &amp; security', array(), true); ?></a></li>
+                        <li id="tab_reglang_settings"><a onclick="TBG.Main.Helpers.tabSwitcher('tab_reglang_settings', 'settings_menu');" href="javascript:void(0);"><?php echo image_tag('cfg_icon_reglang.png', array('style' => 'float: left;')).__('Regional & language'); ?></a></li>
+                        <li id="tab_user_settings"><a onclick="TBG.Main.Helpers.tabSwitcher('tab_user_settings', 'settings_menu');" href="javascript:void(0);"><?php echo image_tag('cfg_icon_security.png', array('style' => 'float: left;')).__('Users & security'); ?></a></li>
                         <li id="tab_offline_settings"><a onclick="TBG.Main.Helpers.tabSwitcher('tab_offline_settings', 'settings_menu');" href="javascript:void(0);"><?php echo image_tag('cfg_icon_maintenance.png', array('style' => 'float: left;')).__('Maintenance mode', array(), true); ?></a></li>
                     </ul>
                 </div>

--- a/core/modules/project/templates/_projectedition.inc.php
+++ b/core/modules/project/templates/_projectedition.inc.php
@@ -5,7 +5,7 @@
     <div id="backdrop_detail_content" class="backdrop_detail_content">
         <div class="tab_menu inset">
             <ul id="editions_menu">
-                <li<?php if ($selected_section == 'general'): ?> class="selected"<?php endif; ?> id="edition_settings"><a href="javascript:void(0);" onclick="TBG.Main.Helpers.tabSwitcher('edition_settings', 'editions_menu');"><?php echo __('Details &amp; settings'); ?></a></li>
+                <li<?php if ($selected_section == 'general'): ?> class="selected"<?php endif; ?> id="edition_settings"><a href="javascript:void(0);" onclick="TBG.Main.Helpers.tabSwitcher('edition_settings', 'editions_menu');"><?php echo __('Details & settings'); ?></a></li>
                 <li<?php if ($selected_section == 'components'): ?> class="selected"<?php endif; ?> id="edition_components"><a href="javascript:void(0);" onclick="TBG.Main.Helpers.tabSwitcher('edition_components', 'editions_menu');"><?php echo __('Components'); ?></a></li>
                 <li<?php if ($selected_section == 'team'): ?> class="selected"<?php endif; ?> id="edition_team"><a href="javascript:void(0);" onclick="TBG.Main.Helpers.tabSwitcher('edition_team', 'editions_menu');"><?php echo __('Team'); ?></a></li>
             </ul>


### PR DESCRIPTION
The `__()` function performs HTML entity encoding by default so there is no need to pre-encode HTML entities. Doing so results in double encoding which then appears in the rendered text. For example the **Configure uploads & attachments** page heading appears as **Configure uploads &amp;amp; attachments**.