### PR TITLE
Remove redundant html entity encoding / decoding

### DIFF
--- a/core/modules/main/templates/_intro_index_single_tracker.inc.php
+++ b/core/modules/main/templates/_intro_index_single_tracker.inc.php
@@ -1,4 +1,4 @@
 <?php echo __("It looks likes you're only using The Bug Genie to track issues for one project."); ?><br>
 <?php echo __("If you don't want to use this homepage, you can set The Bug Genie to %single_project_tracker_mode, which will automatically forward the frontpage to the project overview page.", array('%single_project_tracker_mode' => '<i>'.__('Single project tracker mode').'</i>')); ?><br>
 <br>
-<?php echo __("%single_project_tracker_mode can be enabled from %configure_settings.", array('%single_project_tracker_mode' => '<i>'.__('Single project tracker mode').'</i>', '%configure_settings' => link_tag(make_url('configure_settings'), '<b>' . __('Configure &ndash;&gt; Settings') . '</b>'))); ?>
+<?php echo __("%single_project_tracker_mode can be enabled from %configure_settings.", array('%single_project_tracker_mode' => '<i>'.__('Single project tracker mode').'</i>', '%configure_settings' => link_tag(make_url('configure_settings'), '<b>' . __('Configure &rarr; Settings', array(), true) . '</b>'))); ?>

--- a/modules/publish/entities/Article.php
+++ b/modules/publish/entities/Article.php
@@ -428,7 +428,7 @@
 
         protected function _retrieveLinksAndCategoriesFromContent($options = array())
         {
-            $parser = new \thebuggenie\core\helpers\TextParser(html_entity_decode($this->_content));
+            $parser = new \thebuggenie\core\helpers\TextParser($this->_content);
             $options['no_code_highlighting'] = true;
             $parser->doParse($options);
             return array($parser->getInternalLinks(), $parser->getCategories());


### PR DESCRIPTION
Replace `Configure &ndash;&gt; Settings` with `Configure &rarr; Settings` and prevent redundant html entity encoding which results in the html entities appearing encoded in the UI.

Do not apply `html_entity_decode()` to the wiki text prior to parsing when extracting links and categories. This step is not done during regular wiki text parsing in `getParsedContent()` and so introduces an inconsistency which can in rare cases result in the detection of phantom links. For example, if the text contains `&#x5b;&#x5b;otherpage]]` then the regular parsing does not detect a link, but that will be treated as a link for the purpose of link detection.