### PR TITLE
Do not attempt to initialise the Autocompleter if there is no #searchfor element

### DIFF
--- a/public/js/thebuggenie/tbg.js
+++ b/public/js/thebuggenie/tbg.js
@@ -105,20 +105,8 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'jquery-u
          * Initializes the autocompleter
          */
         TBG.Core._initializeAutocompleter = function () {
-//            if (jQuery('#searchfor')) {
-//                jQuery('#searchfor').autocomplete({
-//                    source: TBG.autocompleter_url,
-//                    minLength: 2,
-//                    select: function( event, ui ) {
-//                        log( ui.item ?
-//                        "Selected: " + ui.item.value + " aka " + ui.item.id :
-//                        "Nothing selected, input was " + this.value );
-//                    }
-//                })
-//                .data('autocomplete')
-//                ._renderItem = function (ul, item) {
-//                    
-//                };
+            if ($('searchfor') == null)
+                return;
             new Ajax.Autocompleter(
                 "searchfor",
                 "searchfor_autocomplete_choices",
@@ -142,7 +130,6 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'jquery-u
                     afterUpdateElement: TBG.Core._extractAutocompleteValue
                 }
             );
-//            }
         };
 
         /**


### PR DESCRIPTION
Some pages do not contain a #searchfor element and attempts to initialise the auto-completer result in a javascript error. For example, from the login page:

>Uncaught TypeError: Cannot read property 'value' of null
Autocompleter.Base.Class.create.baseInitialize (controls.js:53)
Ajax.Autocompleter.Class.create.initialize (controls.js:370)
klass (prototype.js:101)
TBG.Core._initializeAutocompleter (tbg.js?bust=4.0.2:110)
TBG.initialize (tbg.js?bust=4.0.2:425)
f_init (login:286)
(anonymous function) (login:287)
runCallbacks (domReady.js:24)
callReady (domReady.js:35)
pageLoaded (domReady.js:50)

The commit also takes the liberty of removing some commented code.