### PR TITLE
prevent from repeated translation

### DIFF
--- a/core/modules/search/templates/findissues.html.php
+++ b/core/modules/search/templates/findissues.html.php
@@ -55,7 +55,7 @@
                 </div>
             <?php endif; ?>
             <div class="results_header">
-                <span id="findissues_search_title" style="<?php if (!$searchtitle) echo 'display: none'; ?>"><?php echo __($searchtitle); ?></span>
+                <span id="findissues_search_title" style="<?php if (!$searchtitle) echo 'display: none'; ?>"><?php echo $searchtitle; ?></span>
                 <span id="findissues_search_generictitle" style="<?php if ($searchtitle) echo 'display: none'; ?>"><?php echo __("Find issues"); ?></span>
                 &nbsp;&nbsp;<span id="findissues_num_results" class="faded_out" style="<?php if (!$show_results) echo 'display: none;'; ?>"><?php echo __('%number_of issue(s)', array('%number_of' => '<span id="findissues_num_results_span">-</span>')); ?></span>
             </div>


### PR DESCRIPTION
$searchtitle should already be translated here, so a second translation would mask special character encoding like german umlaute