### PR TITLE
Support sub and sup html elements in wiki articles

### DIFF
--- a/core/helpers/TextParser.php
+++ b/core/helpers/TextParser.php
@@ -1132,7 +1132,7 @@
 
                 $text = tbg_decodeUTF8($text, true);
 
-                $text = preg_replace_callback('/&lt;(strike|u|pre|tt|s|del|ins|u|blockquote|div|span|font)(\s.*)?&gt;(.*)&lt;\/(\\1)&gt;/ismU', array($this, '_parse_allowed_tags') ,$text);
+                $text = preg_replace_callback('/&lt;(strike|u|pre|tt|s|del|ins|u|blockquote|div|span|font|sub|sup)(\s.*)?&gt;(.*)&lt;\/(\\1)&gt;/ismU', array($this, '_parse_allowed_tags') ,$text);
                 $text = str_replace('&lt;br&gt;', '<br>' ,$text);
 
                 $lines = explode("\n", $text);


### PR DESCRIPTION
Permit sub and sup tags in wiki pages to support subscript and superscript text.