### PR TITLE
Add a setting to control the notification poll interval

### DIFF
--- a/core/framework/Settings.php
+++ b/core/framework/Settings.php
@@ -85,6 +85,7 @@
         const SETTING_IS_PERMISSIVE_MODE = 'permissive';
         const SETTING_IS_SINGLE_PROJECT_TRACKER = 'singleprojecttracker';
         const SETTING_KEEP_COMMENT_TRAIL_CLEAN = 'cleancomments';
+        const SETTING_NOTIFICATION_POLL_INTERVAL = 'notificationpollinterval';
         const SETTING_OFFLINESTATE = 'offlinestate';
         const SETTING_ONLINESTATE = 'onlinestate';
         const SETTING_PREVIEW_COMMENT_IMAGES = 'previewcommentimages';
@@ -902,6 +903,17 @@
                 default:
                     return self::SYNTAX_MD;
             }
+        }
+
+        /**
+         * Notification polling interval in seconds
+         * 
+         * @return integer
+         */
+        public static function getNotificationPollInterval()
+        {
+            $seconds = self::get(self::SETTING_NOTIFICATION_POLL_INTERVAL);
+            return $seconds == null ? 10 : $seconds;
         }
 
         /**

--- a/core/modules/configuration/controllers/Main.php
+++ b/core/modules/configuration/controllers/Main.php
@@ -114,7 +114,8 @@
                     framework\Settings::SETTING_TBG_NAME, framework\Settings::SETTING_TBG_NAME_HTML, framework\Settings::SETTING_DEFAULT_CHARSET, framework\Settings::SETTING_DEFAULT_LANGUAGE,
                     framework\Settings::SETTING_SERVER_TIMEZONE, framework\Settings::SETTING_SYNTAX_HIGHLIGHT_DEFAULT_LANGUAGE, framework\Settings::SETTING_SYNTAX_HIGHLIGHT_DEFAULT_INTERVAL,
                     framework\Settings::SETTING_SYNTAX_HIGHLIGHT_DEFAULT_NUMBERING, framework\Settings::SETTING_PREVIEW_COMMENT_IMAGES, framework\Settings::SETTING_HEADER_LINK,
-                    framework\Settings::SETTING_MAINTENANCE_MESSAGE, framework\Settings::SETTING_MAINTENANCE_MODE, framework\Settings::SETTING_ELEVATED_LOGIN_DISABLED);
+                    framework\Settings::SETTING_MAINTENANCE_MESSAGE, framework\Settings::SETTING_MAINTENANCE_MODE, framework\Settings::SETTING_ELEVATED_LOGIN_DISABLED,
+                    framework\Settings::SETTING_NOTIFICATION_POLL_INTERVAL);
 
                 foreach ($settings as $setting)
                 {
@@ -141,6 +142,12 @@
                                     return $this->renderJSON(array('error' => framework\Context::getI18n()->__('Please provide a valid setting for charset')));
                                 }
                                 break;
+                            case framework\Settings::SETTING_NOTIFICATION_POLL_INTERVAL:
+                                if (!ctype_digit($value))
+                                {
+                                    $this->getResponse()->setHttpStatus(400);
+                                    return $this->renderJSON(array('error' => framework\Context::getI18n()->__('Please provide a valid setting for notification poll interval')));
+                                }
                         }
                         framework\Settings::saveSetting($setting, $value);
                     }

--- a/core/modules/configuration/templates/_general.inc.php
+++ b/core/modules/configuration/templates/_general.inc.php
@@ -136,4 +136,13 @@
             ); ?>
         </td>
     </tr>
+    <tr>
+        <td><label for="notification_poll_interval"><?php echo __('Notification poll interval'); ?></label></td>
+        <td>
+            <input type="text" name="<?php echo \thebuggenie\core\framework\Settings::SETTING_NOTIFICATION_POLL_INTERVAL; ?>" style="width: 50px;"<?php if ($access_level != \thebuggenie\core\framework\Settings::ACCESS_FULL): ?> disabled<?php endif; ?> id="notification_poll_interval" value="<?php echo (\thebuggenie\core\framework\Settings::getNotificationPollInterval()); ?>" />
+            <?php echo config_explanation(
+                __('Polling is used to check for new user notifications. Set the default polling interval in seconds, or 0 to disable polling.')
+            ); ?>
+        </td>
+    </tr>
 </table>

--- a/core/modules/main/controllers/Main.php
+++ b/core/modules/main/controllers/Main.php
@@ -511,6 +511,7 @@ class Main extends framework\Action
                         break;
                     default:
                         $data['unread_notifications'] = $this->getUser()->getNumberOfUnreadNotifications();
+                        $data['poll_interval'] = framework\Settings::getNotificationPollInterval();
                 }
             }
 

--- a/public/js/thebuggenie/tbg.js
+++ b/public/js/thebuggenie/tbg.js
@@ -436,7 +436,6 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'jquery-u
             $('fullpage_backdrop_content').observe('click', TBG.Core._resizeWatcher);
             document.observe('keydown', TBG.Core._escapeWatcher);
 
-            TBG.Core.Pollers.datapoller = new PeriodicalExecuter(TBG.Core.Pollers.Callbacks.dataPoller, 10);
             TBG.Core.Pollers.Callbacks.dataPoller();
             TBG.OpenID.init();
             // Mimick browser scroll to element with id as hash once header get 'fixed' class
@@ -468,6 +467,10 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'jquery-u
                                 }
                             }
                             TBG.Core.Pollers.Locks.datapoller = false;
+                            if (TBG.Core.Pollers.datapoller != null)
+                                TBG.Core.Pollers.datapoller.stop();
+                            var interval = parseInt(json.poll_interval);
+                            TBG.Core.Pollers.datapoller = interval > 0 ? new PeriodicalExecuter(TBG.Core.Pollers.Callbacks.dataPoller, interval) : null;
                         }
                     }
                 });


### PR DESCRIPTION
The poll interval for user notifications is 10 seconds. If there are n users each with an average of m buggenie tabs open then the polling query rate is n x m / 10 which can become significant. This commit adds a setting to allow administrators to control the poll rate, potentially disabling it entirely by setting to zero.