### PR TITLE
Include the wiki edit comment text box on the edit page directly

### DIFF
--- a/modules/publish/css/publish.css
+++ b/modules/publish/css/publish.css
@@ -64,13 +64,13 @@
     padding: 10px;
     text-align: right;
 }
-.article .publish_article_actions a, .article .publish_article_actions a:hover, .change_reason_actions a, .change_reason_actions a:hover {
+.article .publish_article_actions a, .article .publish_article_actions a:hover {
     display: inline-block;
     vertical-align: middle;
     margin-right: 10px;
     border: none;
 }
-.article .publish_article_actions .button, .change_reason_actions .button, .change_reason_actions .button:hover {
+.article .publish_article_actions .button {
     display: inline-block;
     padding: 4px 8px;
     font-size: 1.1em;
@@ -114,12 +114,26 @@
     line-height: 1.5em;
     min-height: 450px;
 }
-#change_reason {
-    width: 100%;
+#change_reason_container {
+    display: block;
+    padding: 10px 10px 0 10px;
 }
-.change_reason_actions {
-    text-align: right;
-    padding: 15px 0;
+#change_reason_container label {
+    float: left;
+    padding-right: 10px;
+}
+#change_reason_container span {
+    display: block;
+    overflow: hidden;
+}
+#change_reason {
+    font-size: 1em;
+    box-sizing: border-box;
+    -o-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    width: 100%;
 }
 
 .article.edit .markItUpHeader { border-bottom: 1px solid rgba(100, 100, 100, 0.3); }

--- a/modules/publish/templates/editarticle.html.php
+++ b/modules/publish/templates/editarticle.html.php
@@ -25,7 +25,7 @@
                 <?php include_component('articledisplay', array('article' => $article, 'show_article' => $preview, 'show_category_contains' => false, 'show_actions' => true, 'mode' => 'view')); ?>
             <?php endif; ?>
             <a name="edit_article"></a>
-            <form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo make_url($article_route, $article_route_params); ?>" method="post" id="edit_article_form" onsubmit="Event.stopObserving(window, 'beforeunload');var isvisible = $('change_reason_container').visible() || $('article_preview').value == 1;return isvisible;">
+            <form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo make_url($article_route, $article_route_params); ?>" method="post" id="edit_article_form"> 
                 <?php include_component('publish/header', array('article' => $article, 'show_actions' => true, 'mode' => 'edit')); ?>
                 <input type="hidden" name="preview" value="0" id="article_preview">
                 <input type="hidden" name="article_id" value="<?php echo ($article instanceof \thebuggenie\modules\publish\entities\Article) ? $article->getID() : 0; ?>">
@@ -71,32 +71,18 @@
                 <div class="editor_container">
                     <?php include_component('main/textarea', array('area_name' => 'article_content', 'target_type' => 'article', 'target_id' => $article->getID(), 'area_id' => 'article_content', 'syntax' => $article->getContentSyntax(), 'markuppable' => !($article->getContentSyntax(true) == \thebuggenie\core\framework\Settings::SYNTAX_PT), 'width' => '100%', 'value' => htmlspecialchars($article->getContent()))); ?>
                 </div>
-                <div id="change_reason_container" class="fullpage_backdrop" style="display: none;">
-                    <div class="backdrop_box large">
-                        <div class="backdrop_detail_header"><?php echo __('Saving article'); ?></div>
-                        <div class="backdrop_detail_content">
-                            <label for="change_reason" style="margin-left: 5px; clear: both;"><?php echo __('Change reason'); ?>
-                                <?php if (\thebuggenie\core\framework\Context::getModule('publish')->getSetting('require_change_reason') == 0) : ?>
-                                    &nbsp;&nbsp;<span class="faded_out" style="font-weight: normal; font-size: 0.9em;"><?php echo __('Optional'); ?></span>
-                                <?php endif; ?>
-                            </label><br>
-                            <div style="margin: 5px 15px 5px 5px;">
-                                <input type="text" name="change_reason" id="change_reason" maxlength="255" value="<?php if (isset($change_reason)) echo $change_reason; ?>"><br>
-                            </div>
-                            <div class="faded_out dark" style="padding: 5px 5px 15px 5px; font-size: 13px;"><?php echo __('Enter a short reason summarizing your changes (max. 255 characters)'); ?></div>
-                            <div class="change_reason_actions">
-                                <a href="javascript:void(0);" onclick="$('change_reason_container').hide();"><?php echo __('Cancel'); ?></a>
-                                <input class="button button-green" type="submit" value="<?php echo ($article instanceof \thebuggenie\modules\publish\entities\Article) ? __('Save changes') : __('Create article'); ?>">
-                            </div>
-                        </div>
-                    </div>
+                <div id="change_reason_container">
+                    <label><?php echo __('Comment'); ?></label>
+                    <span>
+                        <input type="text" name="change_reason" id="change_reason" maxlength="255" value="<?php if (isset($change_reason)) echo $change_reason; ?>" placeholder="<?php echo __('Reason for the change (max. 255 characters)'); ?>">
+                    </span>
                 </div>
                 <div class="publish_article_actions">
                     <?php if ($article->getID()): ?>
                         <?php echo link_tag((($article instanceof \thebuggenie\modules\publish\entities\Article) ? make_url('publish_article', array('article_name' => $article_name)) : make_url('publish')), __('Cancel')); ?>
                     <?php endif; ?>
                     <input class="button button-silver" type="submit" onclick="$('article_preview').value = 1;" value="<?php echo ($article instanceof \thebuggenie\modules\publish\entities\Article) ? __('Preview changes') : __('Preview article'); ?>">
-                    <input class="button button-green" type="button" value="<?php echo ($article instanceof \thebuggenie\modules\publish\entities\Article) ? __('Save changes') : __('Create article'); ?>" onclick="$('change_reason_container').show();$('change_reason').focus();">
+                    <input class="button button-green" id="save_button" type="submit" value="<?php echo ($article instanceof \thebuggenie\modules\publish\entities\Article) ? __('Save changes') : __('Create article'); ?>">
                 </div>
             </form>
             <form id="parent_selector_container" class="fullpage_backdrop" style="display: none;" onsubmit="TBG.Main.loadParentArticles(this);return false;" action="<?php echo make_url('publish_article_parents', array('article_name' => $article->getName())); ?>">
@@ -107,7 +93,7 @@
                         <input type="submit" class="button button-silver" value="<?php echo __('Find'); ?>">
                         <?php echo image_tag('spinning_32.gif', array('id' => 'parent_selector_container_indicator', 'style' => 'display: none;')); ?>
                         <ul id="parent_articles_list"></ul>
-                        <div class="change_reason_actions">
+                        <div class="publish_article_actions">
                             <a href="javascript:void(0);" onclick="$('parent_selector_container').hide();"><?php echo __('Cancel'); ?></a>
                         </div>
                     </div>
@@ -139,6 +125,29 @@
                     });
                 });
             }
+
+            $('edit_article_form').on('keypress', function(event) {
+                if (event.keyCode == 13 && event.target.tagName != 'TEXTAREA') {
+                    Event.stop(event);
+                    $('save_button').click();
+                }
+            });
+
+            $('edit_article_form').on('submit', function(event) {
+                var ok = true;
+                <?php if (\thebuggenie\core\framework\Context::getModule('publish')->getSetting('require_change_reason') != 0): ?>
+                if ($('article_preview').value != 1 && $('change_reason').value.length == 0) {
+                    $('change_reason').focus();
+                    TBG.Main.Helpers.Message.error('<?php echo __('Comment required') ?>', '<?php echo __('Please provide a comment describing the edit.') ?>');
+                    ok = false;
+                }
+                <?php endif; ?>
+                if (ok)
+                    Event.stopObserving(window, 'beforeunload');
+                else
+                    Event.stop(event);
+                return ok;
+            });
 
             Event.observe(window, 'beforeunload', function(event) {
                 if ($('article_content').serialize() != $F('article_serialized'))


### PR DESCRIPTION
Even when the change reason is set to be optional a separate prompt occurs to allow a comment to be specified after clicking save on a wiki article. This commit places the comment box on the edit page to avoid the need for an extra step.