### PR TITLE
Allow image file caching and file delivery using x-sendfile

### DIFF
--- a/core/entities/tables/Settings.php
+++ b/core/entities/tables/Settings.php
@@ -42,7 +42,7 @@
         {
             $this->_addIndex('scope_uid', array(self::SCOPE, self::UID));
         }
-        
+
         protected function _initialize()
         {
             parent::_setup(self::B2DBNAME, self::ID);
@@ -52,7 +52,7 @@
             parent::_addInteger(self::UID, 10);
             parent::_addInteger(self::UPDATED_AT, 10);
         }
-        
+
         public function getSettingsForScope($scope, $uid = 0)
         {
             $crit = $this->getCriteria();
@@ -91,7 +91,7 @@
                 $crit2->addWhere(self::SCOPE, $scope);
                 $crit2->addWhere(self::ID, $theID, Criteria::DB_NOT_EQUALS);
                 $res2 = $this->doDelete($crit2);
-                
+
                 $crit = $this->getCriteria();
                 $crit->addUpdate(self::NAME, $name);
                 $crit->addUpdate(self::MODULE, $module);
@@ -127,7 +127,7 @@
             $crit = $this->getCriteria();
             $crit->addWhere(self::MODULE, $module_name);
             $crit->addWhere(self::UID, 0, Criteria::DB_GREATER_THAN);
-            if ($scope !== null) 
+            if ($scope !== null)
             {
                 $crit->addWhere(self::SCOPE, $scope);
             }
@@ -153,6 +153,8 @@
             $settings[\thebuggenie\core\framework\Settings::SETTING_UPLOAD_EXTENSIONS_LIST] = 'exe,bat,php,asp,jsp';
             $settings[\thebuggenie\core\framework\Settings::SETTING_UPLOAD_STORAGE] = 'files';
             $settings[\thebuggenie\core\framework\Settings::SETTING_UPLOAD_LOCAL_PATH] = THEBUGGENIE_PATH . 'files/';
+            $settings[\thebuggenie\core\framework\Settings::SETTING_UPLOAD_ALLOW_IMAGE_CACHING] = 0;
+            $settings[\thebuggenie\core\framework\Settings::SETTING_UPLOAD_DELIVERY_USE_XSEND] = 0;
             $settings[\thebuggenie\core\framework\Settings::SETTING_TBG_NAME] = 'The Bug Genie';
             $settings[\thebuggenie\core\framework\Settings::SETTING_SYNTAX_HIGHLIGHT_DEFAULT_LANGUAGE] = 'html4strict';
             $settings[\thebuggenie\core\framework\Settings::SETTING_SYNTAX_HIGHLIGHT_DEFAULT_NUMBERING] = '3';
@@ -170,5 +172,5 @@
                 $this->saveSetting($settings_name, 'core', $settings_val, 0, $scope_id);
             }
         }
-        
+
     }

--- a/core/framework/Response.php
+++ b/core/framework/Response.php
@@ -547,14 +547,16 @@
         /**
          * Render current headers
          */
-        public function renderHeaders()
+        public function renderHeaders($disableCache = true)
         {
             header("HTTP/1.0 ".$this->_http_status);
-            /* headers to stop caching in browsers and proxies */
-            header("Expires: Mon, 26 Jul 1997 05:00:00 GMT"); // Date in the past
-            header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT"); // always modified
-            header("Cache-Control: no-cache, must-revalidate"); // HTTP/1.1
-            header("Pragma: no-cache"); // HTTP/1.0
+            if ($disableCache) {
+              /* headers to stop caching in browsers and proxies */
+              header("Expires: Mon, 26 Jul 1997 05:00:00 GMT"); // Date in the past
+              header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT"); // always modified
+              header("Cache-Control: no-cache, must-revalidate"); // HTTP/1.1
+              header("Pragma: no-cache"); // HTTP/1.0
+            }
             if (Context::isDebugMode()) {
                 header("x-tbg-debugid: ".Context::getDebugID());
                 $load_time = Context::getLoadTime();

--- a/core/framework/Settings.php
+++ b/core/framework/Settings.php
@@ -108,6 +108,8 @@
         const SETTING_UPLOAD_MAX_FILE_SIZE = 'upload_max_file_size';
         const SETTING_UPLOAD_RESTRICTION_MODE = 'upload_restriction_mode';
         const SETTING_UPLOAD_STORAGE = 'upload_storage';
+        const SETTING_UPLOAD_ALLOW_IMAGE_CACHING = 'upload_allow_image_caching';
+        const SETTING_UPLOAD_DELIVERY_USE_XSEND = 'upload_delivery_use_xsend';
         const SETTING_USER_DISPLAYNAME_FORMAT = 'user_displayname_format';
         const SETTING_USER_GROUP = 'defaultgroup';
         const SETTING_USER_TIMEZONE = 'timezone';
@@ -743,6 +745,18 @@
             return (bool) (Context::getScope()->isUploadsEnabled() && self::get(self::SETTING_ENABLE_UPLOADS));
         }
 
+        public static function isUploadsImageCachingEnabled()
+        {
+            $caching = self::get(self::SETTING_UPLOAD_ALLOW_IMAGE_CACHING);
+            return (($caching == null) ? false : (bool) $caching);
+        }
+
+        public static function isUploadsDeliveryUseXsend()
+        {
+            $useXsend = self::get(self::SETTING_UPLOAD_DELIVERY_USE_XSEND);
+            return (($useXsend == null) ? false : (bool) $useXsend);
+        }
+
         public static function getUploadsMaxSize($bytes = false)
         {
             return ($bytes) ? (int) (self::get(self::SETTING_UPLOAD_MAX_FILE_SIZE) * 1024 * 1024) : (int) self::get(self::SETTING_UPLOAD_MAX_FILE_SIZE);
@@ -888,7 +902,7 @@
          * Return syntax value for a given syntax shorthand
          *
          * @param string $syntax
-         * 
+         *
          * @return integer
          */
         public static function getSyntaxValue($syntax)
@@ -907,7 +921,7 @@
 
         /**
          * Notification polling interval in seconds
-         * 
+         *
          * @return integer
          */
         public static function getNotificationPollInterval()
@@ -918,7 +932,7 @@
 
         /**
          * Whether or not the authentication backend is external
-         * 
+         *
          * @return boolean
          */
         public static function isUsingExternalAuthenticationBackend()

--- a/core/modules/configuration/controllers/Main.php
+++ b/core/modules/configuration/controllers/Main.php
@@ -1020,6 +1020,8 @@
                     }
                 }
 
+                framework\Settings::saveSetting('upload_allow_image_caching', framework\Context::getRequest()->getParameter('upload_allow_image_caching'));
+                framework\Settings::saveSetting('upload_delivery_use_xsend', framework\Context::getRequest()->getParameter('upload_delivery_use_xsend'));
                 framework\Settings::saveSetting('enable_uploads', framework\Context::getRequest()->getParameter('enable_uploads'));
 
                 return $this->renderJSON(array('title' => framework\Context::getI18n()->__('All settings saved')));

--- a/core/modules/configuration/templates/configureuploads.html.php
+++ b/core/modules/configuration/templates/configureuploads.html.php
@@ -1,7 +1,7 @@
 <?php
 
     $tbg_response->setTitle(__('Configure uploads & attachments'));
-    
+
 ?>
 <script type="text/javascript">
 
@@ -17,6 +17,8 @@
             {
                 $('upload_localpath').enable();
             }
+            $('upload_allow_image_caching').enable();
+            $('upload_delivery_use_xsend').enable();
         }
         else
         {
@@ -25,6 +27,8 @@
             $('upload_storage').disable();
             $('upload_max_file_size').disable();
             $('upload_localpath').disable();
+            $('upload_allow_image_caching').disable();
+            $('upload_delivery_use_xsend').disable();
         }
     }
 

--- a/core/modules/main/controllers/Main.php
+++ b/core/modules/main/controllers/Main.php
@@ -3125,6 +3125,7 @@ class Main extends framework\Action
             if ($file->hasAccess())
             {
                 $disableCache = true;
+                $isFile = false;
                 $this->getResponse()->cleanBuffer();
                 $this->getResponse()->clearHeaders();
                 $this->getResponse()->setDecoration(\thebuggenie\core\framework\Response::DECORATE_NONE);
@@ -3141,6 +3142,7 @@ class Main extends framework\Action
                 if (framework\Settings::getUploadStorage() == 'files')
                 {
                     $fh = fopen(framework\Settings::getUploadsLocalpath() . $file->getRealFilename(), 'r');
+                    $isFile = true;
                 }
                 else
                 {
@@ -3148,7 +3150,7 @@ class Main extends framework\Action
                 }
                 if (is_resource($fh))
                 {
-                    if (\thebuggenie\core\framework\Settings::isUploadsDeliveryUseXsend()) {
+                    if ($isFile && \thebuggenie\core\framework\Settings::isUploadsDeliveryUseXsend()) {
                         $this->getResponse()->addHeader('X-Sendfile: ' . framework\Settings::getUploadsLocalpath() . $file->getRealFilename());
                         $this->getResponse()->renderHeaders($disableCache);
                     }


### PR DESCRIPTION
We're using The Bug Genie on European servers and accessing it from all around the world. Therefore bandwidth optimization and server performance is a very important issue.

These changes contain two optimizations:
- Image file resources can be sent to the client browsers with valid caching headers, allowing them to be cached by browsers and reducing last modified requests.
- File resources can be delivered using the X-Sendfile server extension allowing huge files to be sent directly by the server without breaking down on PHP's memory_limit.

Both settings are optional and can be enabled from within The Bug Genie's "Uploads & attachments" settings.