### PR TITLE
Restructure breadcrumbs

### DIFF
--- a/core/framework/Response.php
+++ b/core/framework/Response.php
@@ -692,7 +692,7 @@
                     break;
                 case 'project_summary':
                     $links['project_dashboard'] = array('url' => Context::getRouting()->generate('project_dashboard', array('project_key' => $project->getKey())), 'title' => $i18n->__('Dashboard'));
-                    $links['project_releases'] = array('url' => Context::getRouting()->generate('project_release_center', array('project_key' => $project->getKey())), 'title' => $i18n->__('Releases'));
+                    $links['project_releases'] = array('url' => Context::getRouting()->generate('project_releases', array('project_key' => $project->getKey())), 'title' => $i18n->__('Releases'));
                     $links['project_roadmap'] = array('url' => Context::getRouting()->generate('project_roadmap', array('project_key' => $project->getKey())), 'title' => $i18n->__('Roadmap'));
                     $links['project_team'] = array('url' => Context::getRouting()->generate('project_team', array('project_key' => $project->getKey())), 'title' => $i18n->__('Team overview'));
                     $links['project_statistics'] = array('url' => Context::getRouting()->generate('project_statistics', array('project_key' => $project->getKey())), 'title' => $i18n->__('Statistics'));

--- a/core/framework/Response.php
+++ b/core/framework/Response.php
@@ -702,6 +702,24 @@
                             $links[] = array('url' => Context::getRouting()->generate('team_dashboard', array('team_id' => $team->getID())), 'title' => $team->getName());
                     }
                     break;
+                case 'configure':
+                    $config_sections = Settings::getConfigSections($i18n);
+                    foreach ($config_sections as $key => $sections)
+                    {
+                        foreach ($sections as $section)
+                        {
+                            if ($key == Settings::CONFIGURATION_SECTION_MODULES)
+                            {
+                                $url = (is_array($section['route'])) ? make_url($section['route'][0], $section['route'][1]) : make_url($section['route']);
+                                $links[] = array('url' => $url, 'title' => $section['description']);
+                            }
+                            else
+                            {
+                                $links[] = array('url' => make_url($section['route']), 'title' => $section['description']);
+                            }
+                        }
+                    }
+                    break;
             }
 
             return $links;

--- a/core/framework/Response.php
+++ b/core/framework/Response.php
@@ -675,6 +675,20 @@
                     $links[] = array('url' => Context::getRouting()->generate('about'), 'title' => $i18n->__('About %sitename', array('%sitename' => Settings::getSiteHeaderName())));
                     $links[] = array('url' => Context::getRouting()->generate('account'), 'title' => $i18n->__('Account details'));
 
+                    $root_projects = array_merge(\thebuggenie\core\entities\Project::getAllRootProjects(true), \thebuggenie\core\entities\Project::getAllRootProjects(false));
+                    $first = true;
+                    foreach ($root_projects as $project)
+                    {
+                        if (!$project->hasAccess())
+                            continue;
+                        if ($first)
+                        {
+                            $first = false;
+                            $links[] = array('url' => '#', 'title' => '<hr />');
+                        }
+                        $links[] = array('url' => Context::getRouting()->generate('project_dashboard', array('project_key' => $project->getKey())), 'title' => $project->getName());
+                    }
+
                     break;
                 case 'project_summary':
                     $links['project_dashboard'] = array('url' => Context::getRouting()->generate('project_dashboard', array('project_key' => $project->getKey())), 'title' => $i18n->__('Dashboard'));

--- a/core/modules/configuration/controllers/Main.php
+++ b/core/modules/configuration/controllers/Main.php
@@ -42,7 +42,7 @@
             {
                 $this->getResponse()->setPage('config');
                 framework\Context::loadLibrary('ui');
-                $this->getResponse()->addBreadcrumb(framework\Context::getI18n()->__('Configure %thebuggenie_name', array('%thebuggenie_name' => framework\Settings::getSiteHeaderName())), framework\Context::getRouting()->generate('configure'), $this->getResponse()->getPredefinedBreadcrumbLinks('main_links'));
+                $this->getResponse()->addBreadcrumb(framework\Context::getI18n()->__('Configure %thebuggenie_name', array('%thebuggenie_name' => framework\Settings::getSiteHeaderName())), framework\Context::getRouting()->generate('configure'), $this->getResponse()->getPredefinedBreadcrumbLinks('configure'));
             }
         }
 

--- a/core/modules/configuration/templates/_leftmenu.inc.php
+++ b/core/modules/configuration/templates/_leftmenu.inc.php
@@ -8,7 +8,7 @@
             <?php else: ?>
                 <?php $url = make_url($info['route']); ?>
             <?php endif;?>
-            <?php if ($is_selected) $tbg_response->addBreadcrumb($info['description'], $url, $breadcrumblinks); ?>
+            <?php if ($is_selected) $tbg_response->addBreadcrumb($info['description'], $url); ?>
             <a href="<?php echo $url; ?>"<?php if ($is_selected): ?> class="selected"<?php endif; ?>>
                 <?php
                     if (isset($info['module']) && $info['module'] != 'core'):

--- a/core/modules/import/controllers/Main.php
+++ b/core/modules/import/controllers/Main.php
@@ -96,7 +96,7 @@ class Main extends framework\Action
         {
             $this->getResponse()->setPage('config');
             framework\Context::loadLibrary('ui');
-            $this->getResponse()->addBreadcrumb(framework\Context::getI18n()->__('Configure %thebuggenie_name', array('%thebuggenie_name' => framework\Settings::getSiteHeaderName())), framework\Context::getRouting()->generate('configure'), $this->getResponse()->getPredefinedBreadcrumbLinks('main_links'));
+            $this->getResponse()->addBreadcrumb(framework\Context::getI18n()->__('Configure %thebuggenie_name', array('%thebuggenie_name' => framework\Settings::getSiteHeaderName())), framework\Context::getRouting()->generate('configure'), $this->getResponse()->getPredefinedBreadcrumbLinks('configure'));
         }
     }
 

--- a/core/modules/main/templates/about.html.php
+++ b/core/modules/main/templates/about.html.php
@@ -1,7 +1,7 @@
 <?php
 
     $tbg_response->setTitle(__('About %sitename', array('%sitename' => \thebuggenie\core\framework\Settings::getSiteHeaderName())));
-    $tbg_response->addBreadcrumb(__('About %sitename', array('%sitename' => \thebuggenie\core\framework\Settings::getSiteHeaderName())), make_url('about'), tbg_get_breadcrumblinks('main_links'));
+    $tbg_response->addBreadcrumb(__('About %sitename', array('%sitename' => \thebuggenie\core\framework\Settings::getSiteHeaderName())), make_url('about'));
 
 ?>
 <div class="rounded_box borderless mediumgrey" style="margin: 10px auto 0 auto; width: 500px; padding: 5px 5px 15px 5px; font-size: 13px; text-align: center;">

--- a/core/modules/main/templates/clientdashboard.html.php
+++ b/core/modules/main/templates/clientdashboard.html.php
@@ -1,11 +1,11 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Clients'), null, tbg_get_breadcrumblinks('main_links'));
+    $tbg_response->addBreadcrumb(__('Clients'), null, tbg_get_breadcrumblinks('client_list'));
     if ($client instanceof \thebuggenie\core\entities\Client)
     {
         $tbg_response->setTitle(__('Client dashboard for %client_name', array('%client_name' => $client->getName())));
         $tbg_response->setPage('client');
-        $tbg_response->addBreadcrumb($client->getName(), make_url('client_dashboard', array('client_id' => $client->getID())), tbg_get_breadcrumblinks('client_list'));
+        $tbg_response->addBreadcrumb($client->getName(), make_url('client_dashboard', array('client_id' => $client->getID())));
     }
     else
     {

--- a/core/modules/main/templates/dashboard.html.php
+++ b/core/modules/main/templates/dashboard.html.php
@@ -1,7 +1,7 @@
 <?php
 
     $tbg_response->setTitle(__('Dashboard'));
-    $tbg_response->addBreadcrumb(__('Personal dashboard'), make_url('dashboard'), tbg_get_breadcrumblinks('main_links'));
+    $tbg_response->addBreadcrumb(__('Personal dashboard'), make_url('dashboard'));
     $tbg_response->addFeed(make_url('my_reported_issues', array('format' => 'rss')), __('Issues reported by me'));
     $tbg_response->addFeed(make_url('my_assigned_issues', array('format' => 'rss')), __('Open issues assigned to you'));
     $tbg_response->addFeed(make_url('my_teams_assigned_issues', array('format' => 'rss')), __('Open issues assigned to your teams'));

--- a/core/modules/main/templates/index.html.php
+++ b/core/modules/main/templates/index.html.php
@@ -1,7 +1,7 @@
 <?php 
 
     $tbg_response->setTitle(__('Frontpage'));
-    $tbg_response->addBreadcrumb(__('Frontpage'), make_url('home'), tbg_get_breadcrumblinks('main_links'));
+    $tbg_response->addBreadcrumb(__('Frontpage'), make_url('home'));
 
 ?>
 <?php if ($show_project_config_link && $show_project_list): ?>

--- a/core/modules/main/templates/myaccount.html.php
+++ b/core/modules/main/templates/myaccount.html.php
@@ -1,7 +1,7 @@
 <?php
 
     $tbg_response->setTitle('Your account details');
-    $tbg_response->addBreadcrumb(__('Account details'), make_url('account'), tbg_get_breadcrumblinks('main_links'));
+    $tbg_response->addBreadcrumb(__('Account details'), make_url('account'));
     
 ?>
 <?php if ($tbg_user->canChangePassword()): ?>

--- a/core/modules/main/templates/reportissue.html.php
+++ b/core/modules/main/templates/reportissue.html.php
@@ -1,6 +1,6 @@
 <?php 
 
-    $tbg_response->addBreadcrumb(__('Report an issue'), make_url('project_reportissue', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey())), tbg_get_breadcrumblinks('project_summary', \thebuggenie\core\framework\Context::getCurrentProject()));
+    $tbg_response->addBreadcrumb(__('Report an issue'), make_url('project_reportissue', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey())));
     $tbg_response->setTitle(__('Report an issue'));
     
 ?>

--- a/core/modules/main/templates/teamdashboard.html.php
+++ b/core/modules/main/templates/teamdashboard.html.php
@@ -1,11 +1,11 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Teams'), null, tbg_get_breadcrumblinks('main_links'));
+    $tbg_response->addBreadcrumb(__('Teams'), null, tbg_get_breadcrumblinks('team_list'));
     if ($team instanceof \thebuggenie\core\entities\Team)
     {
         $tbg_response->setTitle(__('Team dashboard for %team_name', array('%team_name' => $team->getName())));
         $tbg_response->setPage('team');
-        $tbg_response->addBreadcrumb(__($team->getName()), make_url('team_dashboard', array('team_id' => $team->getID())), tbg_get_breadcrumblinks('team_list'));
+        $tbg_response->addBreadcrumb(__($team->getName()), make_url('team_dashboard', array('team_id' => $team->getID())));
     }
     else
     {

--- a/core/modules/main/templates/viewissue.html.php
+++ b/core/modules/main/templates/viewissue.html.php
@@ -1,7 +1,7 @@
 <?php if ($issue instanceof \thebuggenie\core\entities\Issue): ?>
     <?php
 
-        $tbg_response->addBreadcrumb(__('Issues'), make_url('project_issues', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey())), tbg_get_breadcrumblinks('project_summary', \thebuggenie\core\framework\Context::getCurrentProject()));
+        $tbg_response->addBreadcrumb(__('Issues'), make_url('project_issues', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey())));
         $tbg_response->addBreadcrumb($issue->getFormattedIssueNo(true, true), make_url('viewissue', array('project_key' => $issue->getProject()->getKey(), 'issue_no' => $issue->getFormattedIssueNo())));
         $tbg_response->setTitle('['.(($issue->isClosed()) ? mb_strtoupper(__('Closed')) : mb_strtoupper(__('Open'))) .'] ' . $issue->getFormattedIssueNo(true) . ' - ' . tbg_decodeUTF8($issue->getTitle()));
 

--- a/core/modules/project/templates/dashboard.html.php
+++ b/core/modules/project/templates/dashboard.html.php
@@ -2,7 +2,7 @@
 
     use thebuggenie\core\entities\Dashboard;
 
-    $tbg_response->addBreadcrumb(__('Dashboard'));
+    $tbg_response->addBreadcrumb(__('Dashboard'), make_url('project_dashboard', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" project dashboard', array('%project_name' => $selected_project->getName())));
     $tbg_response->addFeed(make_url('project_timeline', array('project_key' => $selected_project->getKey(), 'format' => 'rss')), __('"%project_name" project timeline', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => $dashboard->getName()));

--- a/core/modules/project/templates/dashboard.html.php
+++ b/core/modules/project/templates/dashboard.html.php
@@ -2,7 +2,7 @@
 
     use thebuggenie\core\entities\Dashboard;
 
-    $tbg_response->addBreadcrumb(__('Dashboard'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Dashboard'));
     $tbg_response->setTitle(__('"%project_name" project dashboard', array('%project_name' => $selected_project->getName())));
     $tbg_response->addFeed(make_url('project_timeline', array('project_key' => $selected_project->getKey(), 'format' => 'rss')), __('"%project_name" project timeline', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => $dashboard->getName()));

--- a/core/modules/project/templates/files.html.php
+++ b/core/modules/project/templates/files.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Project files'));
+    $tbg_response->addBreadcrumb(__('Project files'), make_url('project_files', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" files', array('%project_name' => $selected_project->getName())));
 
 ?>

--- a/core/modules/project/templates/releasecenter.html.php
+++ b/core/modules/project/templates/releasecenter.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Release center'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Release center'));
     $tbg_response->setTitle(__('"%project_name" release center', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Release center')));
 

--- a/core/modules/project/templates/releasecenter.html.php
+++ b/core/modules/project/templates/releasecenter.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Release center'));
+    $tbg_response->addBreadcrumb(__('Release center'), make_url('project_release_center', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" release center', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Release center')));
 

--- a/core/modules/project/templates/releases.html.php
+++ b/core/modules/project/templates/releases.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Releases'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Releases'));
     $tbg_response->setTitle(__('"%project_name" releases', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Releases')));
 

--- a/core/modules/project/templates/releases.html.php
+++ b/core/modules/project/templates/releases.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Releases'));
+    $tbg_response->addBreadcrumb(__('Releases'), make_url('project_releases', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" releases', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Releases')));
 

--- a/core/modules/project/templates/roadmap.html.php
+++ b/core/modules/project/templates/roadmap.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Roadmap'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Roadmap'));
     $tbg_response->setTitle(__('"%project_name" roadmap', array('%project_name' => $selected_project->getName())));
     $tbg_response->addJavascript('excanvas');
     $tbg_response->addJavascript('jquery.flot');

--- a/core/modules/project/templates/roadmap.html.php
+++ b/core/modules/project/templates/roadmap.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Roadmap'));
+    $tbg_response->addBreadcrumb(__('Roadmap'), make_url('project_roadmap', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" roadmap', array('%project_name' => $selected_project->getName())));
     $tbg_response->addJavascript('excanvas');
     $tbg_response->addJavascript('jquery.flot');

--- a/core/modules/project/templates/settings.html.php
+++ b/core/modules/project/templates/settings.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Project settings'));
+    $tbg_response->addBreadcrumb(__('Project settings'), make_url('project_settings', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" settings', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Settings')));
 

--- a/core/modules/project/templates/settings.html.php
+++ b/core/modules/project/templates/settings.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Project settings'), null, tbg_get_breadcrumblinks('project_settings', $selected_project));
+    $tbg_response->addBreadcrumb(__('Project settings'));
     $tbg_response->setTitle(__('"%project_name" settings', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Settings')));
 

--- a/core/modules/project/templates/statistics.html.php
+++ b/core/modules/project/templates/statistics.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Statistics'));
+    $tbg_response->addBreadcrumb(__('Statistics'), make_url('project_statistics', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" project team', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Statistics')));
 

--- a/core/modules/project/templates/statistics.html.php
+++ b/core/modules/project/templates/statistics.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Statistics'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Statistics'));
     $tbg_response->setTitle(__('"%project_name" project team', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Statistics')));
 

--- a/core/modules/project/templates/team.html.php
+++ b/core/modules/project/templates/team.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Team overview'));
+    $tbg_response->addBreadcrumb(__('Team overview'), make_url('project_team', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" project team', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Team')));
 

--- a/core/modules/project/templates/team.html.php
+++ b/core/modules/project/templates/team.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Team overview'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Team overview'));
     $tbg_response->setTitle(__('"%project_name" project team', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Team')));
 

--- a/core/modules/project/templates/timeline.html.php
+++ b/core/modules/project/templates/timeline.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Timeline'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Timeline'));
     $tbg_response->setTitle(__('"%project_name" project timeline', array('%project_name' => $selected_project->getName())));
     $tbg_response->addFeed(make_url('project_timeline', array('project_key' => $selected_project->getKey(), 'format' => 'rss')), __('"%project_name" project timeline', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Timeline')));

--- a/core/modules/project/templates/timeline.html.php
+++ b/core/modules/project/templates/timeline.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Timeline'));
+    $tbg_response->addBreadcrumb(__('Timeline'), make_url('project_timeline', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" project timeline', array('%project_name' => $selected_project->getName())));
     $tbg_response->addFeed(make_url('project_timeline', array('project_key' => $selected_project->getKey(), 'format' => 'rss')), __('"%project_name" project timeline', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Timeline')));

--- a/core/modules/search/templates/findissues.html.php
+++ b/core/modules/search/templates/findissues.html.php
@@ -10,7 +10,7 @@
     }
     if (\thebuggenie\core\framework\Context::isProjectContext())
     {
-        $tbg_response->addBreadcrumb(__('Issues'), make_url('project_issues', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey())), tbg_get_breadcrumblinks('project_summary', \thebuggenie\core\framework\Context::getCurrentProject()));
+        $tbg_response->addBreadcrumb(__('Issues'), make_url('project_issues', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey())));
         $tbg_response->addFeed(make_url('project_open_issues', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey(), 'format' => 'rss')), __('Open issues for %project_name', array('%project_name' => \thebuggenie\core\framework\Context::getCurrentProject()->getName())));
         $tbg_response->addFeed(make_url('project_allopen_issues', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey(), 'format' => 'rss')), __('Open issues for %project_name (including subprojects)', array('%project_name' => \thebuggenie\core\framework\Context::getCurrentProject()->getName())));
         $tbg_response->addFeed(make_url('project_closed_issues', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey(), 'format' => 'rss')), __('Closed issues for %project_name', array('%project_name' => \thebuggenie\core\framework\Context::getCurrentProject()->getName())));
@@ -28,7 +28,7 @@
     }
     else
     {
-        $tbg_response->addBreadcrumb(__('Issues'), make_url('search'), tbg_get_breadcrumblinks('main_links'));
+        $tbg_response->addBreadcrumb(__('Issues'), make_url('search'));
         if (!\thebuggenie\core\entities\User::isThisGuest())
         {
             $tbg_response->addFeed(make_url('my_reported_issues', array('format' => 'rss')), __('Issues reported by me'));

--- a/core/templates/submenu.inc.php
+++ b/core/templates/submenu.inc.php
@@ -1,31 +1,42 @@
 <nav class="submenu_strip<?php if (\thebuggenie\core\framework\Context::isProjectContext()): ?> project_context<?php endif; ?>" id="global_submenu">
     <ul id="submenu" class="project_stuff">
-        <?php $breadcrumbs = $tbg_response->getBreadcrumbs(); ?>
-        <?php foreach ($breadcrumbs as $index => $breadcrumb): ?>
-            <?php $has_sub_menu = (array_key_exists('subitems', $breadcrumb) && is_array($breadcrumb['subitems'])); ?>
-            <li class="breadcrumb">
-                <?php if ($has_sub_menu): ?>
-                    <?php echo javascript_link_tag(image_tag('tabmenu_dropdown_popout.png', array('class' => 'dropdown_activator clickable')), array('title' => __('Click to expand'), 'class' => 'submenu_activator dropper')); ?>
-                <?php elseif ($index): ?>
-                    <?php echo image_tag('tabmenu_dropdown_popout.png', array('class' => 'dropdown_activator')); ?>
-                <?php endif; ?>
-                <?php if (array_key_exists('subitems', $breadcrumb) && is_array($breadcrumb['subitems']) && count($breadcrumb['subitems'])): ?>
-                    <ul class="simple_list rounded_box white shadowed popup_box more_actions_dropdown">
-                        <?php foreach ($breadcrumb['subitems'] as $subindex => $subitem): ?>
-                            <?php if (array_key_exists('url', $subitem) || $subitem['title'] == $breadcrumb['title']): ?>
-                                <li class="<?php if (strpos($subitem['title'], $breadcrumb['title']) === 0) echo 'selected'; ?>"><a href="<?php echo (array_key_exists('url', $subitem)) ? $subitem['url'] : '#'; ?>"><?php echo $subitem['title']; ?></a>
-                            <?php endif; ?>
-                        <?php endforeach; ?>
-                    </ul>
-                <?php endif; ?>
-                <?php $class = (array_key_exists('class', $breadcrumb) && $breadcrumb['class']) ? $breadcrumb['class'] : ''; ?>
-                <?php if ($breadcrumb['url']): ?>
-                    <?php echo link_tag($breadcrumb['url'], $breadcrumb['title'], array('class' => $class)); ?>
-                <?php else: ?>
-                    <span <?php if ($class): ?> class="<?php echo $class; ?>"<?php endif; ?>><?php echo $breadcrumb['title']; ?></span>
-                <?php endif; ?>
-            </li>
-        <?php endforeach; ?>
+        <?php
+            $breadcrumbs = $tbg_response->getBreadcrumbs();
+            foreach ($breadcrumbs as $index => $breadcrumb)
+            {
+                echo '<li class="breadcrumb">';
+                $class = (array_key_exists('class', $breadcrumb) && $breadcrumb['class']) ? $breadcrumb['class'] : '';
+                if ($breadcrumb['url'])
+                {
+                    echo link_tag($breadcrumb['url'], $breadcrumb['title'], array('class' => $class));
+                }
+                else
+                {
+                    echo '<span class="', $class, '">', $breadcrumb['title'], '</span>';
+                }
+                if (array_key_exists('subitems', $breadcrumb) && is_array($breadcrumb['subitems']) && count($breadcrumb['subitems']) > 0)
+                {
+                    echo javascript_link_tag(image_tag('tabmenu_dropdown_popout.png', array('class' => 'dropdown_activator clickable')), array('title' => __('Click to expand'), 'class' => 'submenu_activator dropper'));
+                    $next_title = ($index + 1) < count($breadcrumbs) ? $breadcrumbs[$index + 1]['title'] : null;
+                    echo '<ul class="simple_list rounded_box white shadowed popup_box more_actions_dropdown">';
+                        foreach ($breadcrumb['subitems'] as $subindex => $subitem)
+                        {
+                            if (array_key_exists('url', $subitem) || $subitem['title'] == $next_title)
+                            {
+                                $class = strpos($subitem['title'], $next_title) === 0 ? 'selected' : '';
+                                $url = array_key_exists('url', $subitem) ? $subitem['url'] : '#';
+                                echo '<li class="', $class, '"><a href="', $url, '">', $subitem['title'], '</a></li>';
+                            }
+                        }
+                    echo '</ul>';
+                }
+                else if ($index + 1 < count($breadcrumbs))
+                {
+                    echo image_tag('tabmenu_dropdown_popout.png', array('class' => 'dropdown_activator'));
+                }
+                echo '</li>';
+            }
+        ?>
     </ul>
     <?php if ($tbg_user->canSearchForIssues()): ?>
         <form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo (\thebuggenie\core\framework\Context::isProjectContext()) ? make_url('search', array('project_key' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey())) : make_url('search'); ?>" method="get" name="quicksearchform" id="quicksearchform">

--- a/modules/agile/templates/board.html.php
+++ b/modules/agile/templates/board.html.php
@@ -2,7 +2,7 @@
 
     use thebuggenie\modules\agile\entities\AgileBoard;
 
-    $tbg_response->addBreadcrumb(__('Planning'));
+    $tbg_response->addBreadcrumb(__('Planning'), make_url('agile_board', array('project_key' => $selected_project->getKey(), 'board_id' => $board->getId())));
     $tbg_response->setTitle(__('"%project_name" project planning', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => $board->getName()));
 

--- a/modules/agile/templates/board.html.php
+++ b/modules/agile/templates/board.html.php
@@ -2,7 +2,7 @@
 
     use thebuggenie\modules\agile\entities\AgileBoard;
 
-    $tbg_response->addBreadcrumb(__('Planning'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Planning'));
     $tbg_response->setTitle(__('"%project_name" project planning', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => $board->getName()));
 

--- a/modules/agile/templates/index.html.php
+++ b/modules/agile/templates/index.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Planning'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Planning'));
     $tbg_response->setTitle(__('"%project_name" project planning', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Manage agile boards')));
 

--- a/modules/agile/templates/index.html.php
+++ b/modules/agile/templates/index.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Planning'));
+    $tbg_response->addBreadcrumb(__('Planning'), make_url('agile_index', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" project planning', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Manage agile boards')));
 

--- a/modules/agile/templates/whiteboard.html.php
+++ b/modules/agile/templates/whiteboard.html.php
@@ -1,7 +1,7 @@
 <?php
 
     use thebuggenie\modules\agile\entities\AgileBoard;
-    $tbg_response->addBreadcrumb(__('Planning'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Planning'));
     $tbg_response->setTitle(__('"%project_name" agile whiteboard', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => $board->getName(), 'board' => $board));
 

--- a/modules/agile/templates/whiteboard.html.php
+++ b/modules/agile/templates/whiteboard.html.php
@@ -1,7 +1,7 @@
 <?php
 
     use thebuggenie\modules\agile\entities\AgileBoard;
-    $tbg_response->addBreadcrumb(__('Planning'));
+    $tbg_response->addBreadcrumb(__('Planning'), make_url('agile_whiteboard', array('project_key' => $selected_project->getKey(), 'board_id' => $board->getId())));
     $tbg_response->setTitle(__('"%project_name" agile whiteboard', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => $board->getName(), 'board' => $board));
 

--- a/modules/publish/Publish.php
+++ b/modules/publish/Publish.php
@@ -340,7 +340,7 @@
 
         public function listen_BreadcrumbMainLinks(framework\Event $event)
         {
-            $link = array('url' => framework\Context::getRouting()->generate('publish'), 'title' => $this->getMenuTitle(framework\Context::isProjectContext()));
+            $link = array('url' => framework\Context::getRouting()->generate('publish'), 'title' => $this->getMenuTitle(false));
             $event->addToReturnList($link);
         }
 

--- a/modules/publish/templates/_wikibreadcrumbs.inc.php
+++ b/modules/publish/templates/_wikibreadcrumbs.inc.php
@@ -5,11 +5,11 @@
     {
         if (\thebuggenie\core\framework\Context::isProjectContext())
         {
-            $tbg_response->addBreadcrumb(\thebuggenie\core\framework\Context::getModule('publish')->getMenuTitle(), make_url('publish_article', array('article_name' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey() . ':MainPage')), tbg_get_breadcrumblinks('project_summary', \thebuggenie\core\framework\Context::getCurrentProject()));
+            $tbg_response->addBreadcrumb(\thebuggenie\core\framework\Context::getModule('publish')->getMenuTitle(), make_url('publish_article', array('article_name' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey() . ':MainPage')));
         }
         else
         {
-            $tbg_response->addBreadcrumb(\thebuggenie\core\framework\Context::getModule('publish')->getMenuTitle(), make_url('publish_article', array('article_name' => 'MainPage')), tbg_get_breadcrumblinks('main_links'));
+            $tbg_response->addBreadcrumb(\thebuggenie\core\framework\Context::getModule('publish')->getMenuTitle(), make_url('publish_article', array('article_name' => 'MainPage')));
         }
         $items = explode(':', $article_name);
         $bcpath = array_shift($items);
@@ -33,5 +33,5 @@
     }
     else
     {
-        $tbg_response->addBreadcrumb(\thebuggenie\core\framework\Context::getModule('publish')->getMenuTitle(), make_url('publish_article', array('article_name' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey() . ':MainPage')), tbg_get_breadcrumblinks('project_summary', \thebuggenie\core\framework\Context::getCurrentProject()));
+        $tbg_response->addBreadcrumb(\thebuggenie\core\framework\Context::getModule('publish')->getMenuTitle(), make_url('publish_article', array('article_name' => \thebuggenie\core\framework\Context::getCurrentProject()->getKey() . ':MainPage')));
     }

--- a/modules/vcs_integration/templates/projectcommits.html.php
+++ b/modules/vcs_integration/templates/projectcommits.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Commits'));
+    $tbg_response->addBreadcrumb(__('Commits'), make_url('vcs_commitspage', array('project_key' => $selected_project->getKey())));
     $tbg_response->setTitle(__('"%project_name" commits', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Project commits')));
 

--- a/modules/vcs_integration/templates/projectcommits.html.php
+++ b/modules/vcs_integration/templates/projectcommits.html.php
@@ -1,6 +1,6 @@
 <?php
 
-    $tbg_response->addBreadcrumb(__('Commits'), null, tbg_get_breadcrumblinks('project_summary', $selected_project));
+    $tbg_response->addBreadcrumb(__('Commits'));
     $tbg_response->setTitle(__('"%project_name" commits', array('%project_name' => $selected_project->getName())));
     include_component('project/projectheader', array('selected_project' => $selected_project, 'subpage' => __('Project commits')));
 


### PR DESCRIPTION
I recently discovered that the chevron between breadcrumbs supports a drop-down menu with links related to that breadcrumb. To me this was a wow feature! :)

I am interested in taking this model further so that the breadcrumbs are a first class way of navigating TBG. This has also sparked some ideas for further work on the top menus to work in tandem with the breadcrumbs (for future commits).

At present when a breadcrumb is added using `Response::addBreadcrumb()` the specified subitems apply to the chevron _preceding_ the breadcrumb being added. That means the list generally must contain alternate sibling nodes (alternative places you could have got to from the same parent if you didn't end up on the current path). However, it is more natural to specify alternative siblings when creating the parent node since the child may not be aware of other siblings. In addition that model allows the last breadcrumb node to specify a list of potential places to go next, which allows for enhancing the navigational model. This PR contains a series of 5 commits which introduce this model as a basis for future work.

* Restructure breadcrumbs: This commit does the main work of switching the model around. In the main there are few visible / functional changes. One key difference is that project nodes include both child projects as well as the project specific informational links.
* Add root projects to the main_links breadcrumbs: This allows all root projects to be accessible from the root breadcrumb. This provides a direct way to get to any root project from anywhere in TBG.
* Fix project summary breadcrumbs route for releases: This is a minor bug fix for the Releases link (which currently points at the release center - there is a separate link for the release center).
* Fix title for wiki subitem of main_links breadcrumb: This link always points to the main (non-project specific) wiki, but the title changes according to whether the page is a project context page, which is incorrect. An alternative fix would be to change the link to point at the project wiki, but I believe the root breadcrumb functionality should remain fixed regardless of context to provide navigational consistency from any point in TBG.
* Add urls for some breadcrumbs that do not have urls: Where a breadcrumb is the last in a chain sometimes that breadcrumb links to the current page, sometimes it has no link. There is no specific need for a last-in-chain breadcrumb to be a link, since it will point to the current page. However, it is desirable to be consistent (either all link, or non-link). I prefer the link so this commit adds some missing links.