### PR TITLE
Add name property to empty module fixture

### DIFF
--- a/core/modules/main/fixtures/emptymoduleclass
+++ b/core/modules/main/fixtures/emptymoduleclass
@@ -27,6 +27,7 @@
 
         const VERSION = '0.1';
 
+        protected $_name = 'module_name';
         protected $_longname = 'module_name';
         protected $_description = 'module_name description here';
         protected $_module_config_title = 'module_name';


### PR DESCRIPTION
The cli generates a new module without the `$_name property`, resulting in
the following error on the module configuration page:

```
Route named "configure_install_module" have a mandatory "module_key"
parameter
```