### PR TITLE
Enable subdirectories for template files

### DIFF
--- a/core/framework/ActionComponent.php
+++ b/core/framework/ActionComponent.php
@@ -56,6 +56,13 @@
             {
                 $template_basepath = (Context::isInternalModule($module_file['module'])) ? THEBUGGENIE_INTERNAL_MODULES_PATH : THEBUGGENIE_MODULES_PATH;
                 $template_name = $template_basepath . $module_file['module'] . DS . 'templates' . DS . "_{$module_file['file']}.inc.php";
+                if (mb_strpos($module_file['file'], '/') !== FALSE)
+                {
+                    // if component path contains subdirectory
+                    $file_parts = explode('/', $module_file['file']);
+                    $filename = array_pop($file_parts);
+                    $template_name = $template_basepath . $module_file['module'] . DS . 'templates' . DS . implode(DS, $file_parts) . DS . "_{$filename}.inc.php";
+                }
             }
             return $template_name;
         }

--- a/core/framework/Context.php
+++ b/core/framework/Context.php
@@ -2392,7 +2392,7 @@ class Context
                         {
                             $newPath = explode('/', self::getResponse()->getTemplate());
                             $templateName = (self::isInternalModule($newPath[0])) ? THEBUGGENIE_INTERNAL_MODULES_PATH : THEBUGGENIE_MODULES_PATH;
-                            $templateName .= $newPath[0] . DS . 'templates' . DS . $newPath[1] . '.' . self::getRequest()->getRequestedFormat() . '.php';
+                            $templateName .= $newPath[0] . DS . 'templates' . DS . implode(DS, array_slice($newPath, 1)) . '.' . self::getRequest()->getRequestedFormat() . '.php';
                         }
                         else
                         {


### PR DESCRIPTION
The commit enables action and component template files to have subdirectories in the path definition. This will enable modules which overwrite multiple template files to organize the template files into subdirectories.

Before the commit template files needed to be organized with prefixes:
```
└── module
    └── templates
        ├── main_index.html.php
        ├── _main_menulinks.inc.php
        ├── publish_showarticle.html.php
        └── _publish_articledisplay.inc.php
```

After the commit template files can be organized into subdirectories:
```
└── module
    └── templates
        ├── main
        │   ├── index.html.php
        │   └── _menulinks.inc.php
        └── publish
            ├── showarticle.html.php
            └── _articledisplay.inc.php
```