### PR TITLE
Maybe it's better to not expose user password...

### DIFF
--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -417,7 +417,9 @@
             {
                 $user = new self();
                 $user->setPassword(self::createPassword());
-                $user->setUsername(self::createPassword() . self::createPassword());
+                $username = end((explode('/', rtrim($identity, '/'))));
+                $username = urldecode($username);
+                $user->setUsername($username);
                 $user->setOpenIdLocked();
                 $user->setActivated();
                 $user->setEnabled();


### PR DESCRIPTION
I've removed odd $user->setUsername(self::createPassword() . self::createPassword());  that exposes two time the user crypted password (?) setting it as username

Instead i've retrieved an username by identity url

