### PR TITLE
Try to create the cache directory if inexistent

### DIFF
--- a/core/framework/Cache.php
+++ b/core/framework/Cache.php
@@ -62,7 +62,7 @@
             }
             else
             {
-                if (!file_exists(THEBUGGENIE_CACHE_PATH))
+                if (!file_exists(THEBUGGENIE_CACHE_PATH) and !mkdir(THEBUGGENIE_CACHE_PATH))
                     throw new exceptions\CacheException('The cache directory is not writable', exceptions\CacheException::NO_FOLDER);
 
                 if (!is_writable(THEBUGGENIE_CACHE_PATH))

--- a/core/framework/Cache.php
+++ b/core/framework/Cache.php
@@ -62,8 +62,10 @@
             }
             else
             {
-                if (!file_exists(THEBUGGENIE_CACHE_PATH) and !mkdir(THEBUGGENIE_CACHE_PATH))
-                    throw new exceptions\CacheException('The cache directory is not writable', exceptions\CacheException::NO_FOLDER);
+                if (!file_exists(THEBUGGENIE_CACHE_PATH))
+                    if(!is_writable(dirname(THEBUGGENIE_CACHE_PATH))
+                        || !mkdir(THEBUGGENIE_CACHE_PATH))
+                        throw new exceptions\CacheException('The cache directory is not writable', exceptions\CacheException::NO_FOLDER);
 
                 if (!is_writable(THEBUGGENIE_CACHE_PATH))
                     throw new exceptions\CacheException('The cache directory is not writable', exceptions\CacheException::NOT_WRITABLE);


### PR DESCRIPTION
Currently the installer fails if the `cache` directory is missing.

This PR attemps to create the `cache` directory (and fail the same if the permission do not allow it)