### PR TITLE
Check that a user is returned before trying to fetch its ID

### DIFF
--- a/modules/publish/entities/Article.php
+++ b/modules/publish/entities/Article.php
@@ -1049,7 +1049,7 @@
                 }
             }
 
-            if (isset($uids[framework\Context::getUser()->getID()])) unset($uids[framework\Context::getUser()->getID()]);
+            if (framework\Context::getUser() and isset($uids[framework\Context::getUser()->getID()])) unset($uids[framework\Context::getUser()->getID()]);
             $users = \thebuggenie\core\entities\tables\Users::getTable()->getByUserIDs($uids);
             return $users;
         }


### PR DESCRIPTION
This line prevented the installation to run to the end.