### PR TITLE
Add support for NGINX X-Sendfile variant: X-Accel-Redirect

### DIFF
--- a/core/modules/main/controllers/Main.php
+++ b/core/modules/main/controllers/Main.php
@@ -3218,6 +3218,8 @@ class Main extends framework\Action
                 {
                     if ($isFile && \thebuggenie\core\framework\Settings::isUploadsDeliveryUseXsend()) {
                         $this->getResponse()->addHeader('X-Sendfile: ' . framework\Settings::getUploadsLocalpath() . $file->getRealFilename());
+                        $this->getResponse()->addHeader('X-Accel-Redirect: /files/' . $file->getRealFilename());
+
                         $this->getResponse()->renderHeaders($disableCache);
                     }
                     else


### PR DESCRIPTION
Added an extra header for nginx X-Accel-Redirect.
The following configuration is required in nginx:
````
location ~* /files/(.*)\.(.*) {
    internal;
    root /home/www-sam/sites/bugtracker;
}
````

Explanation: 
- Match anything in /files containing a "." -- this is to exclude the /files/show url which should be routed to php.
- Internal so it is still private.
- Set the root to 1 level higher than the files dir.

Have confirmed that the `X-Sendfile` header does not interfere with Nginx, have not confirmed that the `X-Accel-Redirect` does not interfere with Apache / others.