### PR TITLE
Fix for: Call to undefined function thebuggenie\core\helpers\make_url()

### DIFF
--- a/core/helpers/TextParser.php
+++ b/core/helpers/TextParser.php
@@ -692,6 +692,8 @@
 
         public static function parseIssuelink($matches, $markdown_format = false)
         {
+            framework\Context::loadLibrary('ui');
+            
             $theIssue = \thebuggenie\core\entities\Issue::getIssueFromLink($matches[0]);
             $output = '';
             $classname = '';


### PR DESCRIPTION
When i made a new issue with a ref. to an existing issue i got a 500 internal server error the log showed to following:

[29-Jan-2016 07:07:14 UTC] PHP Fatal error:  Call to undefined function thebuggenie\core\helpers\make_url() in /core/helpers/TextParser.php on line 704

The changes in this file fixed it.