### PR TITLE
403 Error on getting the list of potential duplicate issues

### DIFF
--- a/core/framework/Action.php
+++ b/core/framework/Action.php
@@ -33,7 +33,7 @@
             if (Context::isCLI())
                 return self::AUTHENTICATION_METHOD_CLI;
 
-            if (in_array(Context::getRequest()->getRequestedFormat(), ['json', 'rss', 'xml'])) {
+            if (in_array(Context::getRequest()->getRequestedFormat(), ['json', 'rss', 'xml']) && Context::getRouting()->getCurrentRouteAction() !== 'findIssue') {
                 return self::AUTHENTICATION_METHOD_APPLICATION_PASSWORD;
             }
 


### PR DESCRIPTION
When you try to mark a issue as duplicate and wan't to select de original issue the 'find' method doesn't return a list of issues. The 'find' button triggers the a route with action 'findIssue' witch specifies a request format of the type 'json' so 'AUTHENTICATION_METHOD_APPLICATION_PASSWORD' is used but that triggers a 403 or 500 error (see pull request #446) if you use the default 'AUTHENTICATION_METHOD_CORE' then the list if issues is successfully generated and everything works again.

I don't know if this fix triggers a problem some wear else but everything seems to be working.
