### PR TITLE
Changed default value for parameter "detailed" of toJSON method.

### DIFF
--- a/core/entities/Comment.php
+++ b/core/entities/Comment.php
@@ -691,7 +691,7 @@
             return (int) $this->_comment_number;
         }
 
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             $return_values = array(
                 'id' => $this->getID(),

--- a/core/entities/DatatypeBase.php
+++ b/core/entities/DatatypeBase.php
@@ -153,7 +153,7 @@
             return (int) $this->_sort_order;
         }
 
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             return array(
                     'id' => $this->getID(),

--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -5876,7 +5876,7 @@
             $this->_calculateUserPain();
         }
 
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             $return_values = array(
                 'id' => $this->getID(),

--- a/core/entities/Issuetype.php
+++ b/core/entities/Issuetype.php
@@ -226,7 +226,7 @@
             return (bool) tables\IssuetypeSchemeLink::getTable()->countByIssuetypeID($this->getID());
         }
         
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             return array(
             		'id' => $this->getID(),

--- a/core/entities/Milestone.php
+++ b/core/entities/Milestone.php
@@ -1041,7 +1041,7 @@
             return (int) $this->_sort_order;
         }
         
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             $returnJSON = array(
             		'id' => $this->getID(),
@@ -1074,6 +1074,7 @@
             	$returnJSON['hours'] = $this->_hours;
             	$returnJSON['points'] = $this->_points;
             }
+            return $returnJSON;
         }
 
     }

--- a/core/entities/Project.php
+++ b/core/entities/Project.php
@@ -3340,7 +3340,7 @@
             $preloaded = true;
         }
         
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
         	$jsonArray = array(
         			'id' => $this->getID(),

--- a/core/entities/Team.php
+++ b/core/entities/Team.php
@@ -271,7 +271,7 @@
             return $this->_dashboards;
         }
 
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             $returnJSON = array(
                 'id' => $this->getID(),

--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -2988,7 +2988,7 @@
             return $setting_object;
         }
 
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             $returnJSON = array(
                 'id' => $this->getID(),

--- a/core/entities/Userstate.php
+++ b/core/entities/Userstate.php
@@ -203,7 +203,7 @@
             $this->_name = $name;
         }
         
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             return array(
                 'name' => $this->getName(),

--- a/core/entities/common/Colorizable.php
+++ b/core/entities/common/Colorizable.php
@@ -48,7 +48,7 @@
             $this->setItemdata($color);
         }
 
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             return array(
                     'id' => $this->getID(),

--- a/core/entities/common/Identifiable.php
+++ b/core/entities/common/Identifiable.php
@@ -58,7 +58,7 @@
          * @param bool $detailed [optional] Include detailed information or not. (default false)
          * @return array
          */
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             return array('id' => $this->getID());
         }

--- a/core/entities/common/Keyable.php
+++ b/core/entities/common/Keyable.php
@@ -58,7 +58,7 @@
             $this->_key = $key;
         }
         
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             return array(
             		'id' => $this->getID(),

--- a/core/entities/common/Ownable.php
+++ b/core/entities/common/Ownable.php
@@ -75,7 +75,7 @@
             $this->_owner_user = null;
         }
         
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             $jsonArray = array(
                 'id' => $this->getID(),

--- a/core/entities/common/QaLeadable.php
+++ b/core/entities/common/QaLeadable.php
@@ -144,7 +144,7 @@
             $this->_qa_responsible_user = null;
         }
         
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             $jsonArray = array(
                 'id' => $this->getID(),

--- a/core/entities/common/Releaseable.php
+++ b/core/entities/common/Releaseable.php
@@ -142,7 +142,7 @@
             return date("A", $this->_release_date);
         }
         
-        public function toJSON($detailed = false)
+        public function toJSON($detailed = true)
         {
             $jsonArray = array(
                 'id' => $this->getID(),


### PR DESCRIPTION
Reason is that non detailed output currently breaks logic in interface (eg. for automatic whiteboard refreshing, issue needs milestone). Anothor reason is that tracking broken logic would require too much time manually (without tests). Also added returning of array for Milestone entity method toJSON.
(cherry picked from commit 73a5a81)