### PR TITLE
Check for mail address when checking forgotten password

### DIFF
--- a/modules/mailing/controllers/Main.php
+++ b/modules/mailing/controllers/Main.php
@@ -21,10 +21,15 @@
 
             try
             {
-                $username = str_replace('%2E', '.', $request['forgot_password_username']);
-                if (!empty($username))
+                $username_or_email = str_replace('%2E', '.', $request['forgot_password_username']);
+                if (!empty($username_or_email))
                 {
-                    if (($user = \thebuggenie\core\entities\User::getByUsername($username)) instanceof \thebuggenie\core\entities\User)
+                    $user = \thebuggenie\core\entities\User::getByUsername($username_or_email);
+                    if (!$user instanceof \thebuggenie\core\entities\User)
+                    {
+                        $user = \thebuggenie\core\entities\User::getByEmail($username_or_email);
+                    }
+                    if ($user instanceof \thebuggenie\core\entities\User)
                     {
                         if ($user->isActivated() && $user->isEnabled() && !$user->isDeleted())
                         {


### PR DESCRIPTION
Forgot password dialog asks for username or mail address, so if no username was found we should also check for e-mail addresses