### PR TITLE
Check LOG_ISSUE_TIME_SPENT for existing values

### DIFF
--- a/core/modules/main/templates/_logitem.inc.php
+++ b/core/modules/main/templates/_logitem.inc.php
@@ -115,7 +115,14 @@
                         echo '<i>' . __('Estimation changed: %text', array('%text' => \thebuggenie\core\entities\common\Timeable::formatTimeableLog($log_action['text'], $log_action['previous_value'], $log_action['current_value'], true, true))) . '</i>';
                         break;
                     case \thebuggenie\core\entities\tables\Log::LOG_ISSUE_TIME_SPENT:
-                        echo '<i>' . __('Time spent: %text', array('%text' => \thebuggenie\core\entities\common\Timeable::formatTimeableLog($log_action['text'], $log_action['previous_value'], $log_action['current_value'], true, true))) . '</i>';
+                        if ($log_action['previous_value'] === NULL && $log_action['current_value'] === NULL)
+                        {
+                            echo '<i>' . __('Time spent: %text', array('%text' => $log_action['text'])) . '</i>';
+                        }
+                        else
+                        {
+                            echo '<i>' . __('Time spent: %text', array('%text' => \thebuggenie\core\entities\common\Timeable::formatTimeableLog($log_action['text'], $log_action['previous_value'], $log_action['current_value'], true, true))) . '</i>';
+                        }
                         break;
                     case \thebuggenie\core\entities\tables\Log::LOG_ISSUE_ASSIGNED:
                         echo '<i>' . __('Assignee changed: %text', array('%text' => $log_action['text'])) . '</i>';


### PR DESCRIPTION
Old log records (previous TBG version 4.0) do not have any valid 'previous_value' or 'current_value'. Building the timeline will crash when we call formatTimeableLog with NULL values.