### PR TITLE
Improve .htaccess handling and remove deprecated PHP options

### DIFF
--- a/core/modules/installation/controllers/Main.php
+++ b/core/modules/installation/controllers/Main.php
@@ -380,19 +380,6 @@ class Main extends framework\Action
                         $this->htaccess_error = true;
                     }
                 }
-                if (!is_writable(THEBUGGENIE_PATH . THEBUGGENIE_PUBLIC_FOLDER_NAME . '/') || (file_exists(THEBUGGENIE_PATH . THEBUGGENIE_PUBLIC_FOLDER_NAME . '/.user.ini') && !is_writable(THEBUGGENIE_PATH . THEBUGGENIE_PUBLIC_FOLDER_NAME . '/.user.ini')))
-                {
-                        $this->htaccess_error = 'Permission denied when trying to save the [main folder]/' . THEBUGGENIE_PUBLIC_FOLDER_NAME . '/.user.ini';
-                }
-                else
-                {
-                    $content = file_get_contents(THEBUGGENIE_CORE_PATH . '/templates/user.ini.template');
-                    file_put_contents(THEBUGGENIE_PATH . THEBUGGENIE_PUBLIC_FOLDER_NAME . '/.user.ini', $content);
-                    if (file_get_contents(THEBUGGENIE_PATH . THEBUGGENIE_PUBLIC_FOLDER_NAME . '/.user.ini') != $content)
-                    {
-                        $this->htaccess_error = true;
-                    }
-                }
             }
         }
         catch (\Exception $e)

--- a/core/modules/installation/templates/installstep4.html.php
+++ b/core/modules/installation/templates/installstep4.html.php
@@ -8,7 +8,7 @@
     <?php else: ?>
         <?php if ($htaccess_error !== false): ?>
             <div class="error">
-                The installation routine could not setup your .htaccess and .user.ini files automatically.<br>
+                The installation routine could not setup your .htaccess file automatically.<br>
                 <?php if (!is_bool($htaccess_error)): ?>
                     <br>
                     <b><?php echo $htaccess_error; ?></b><br>
@@ -18,12 +18,11 @@
                 <ul>
                     <li>Rename or copy the <i><?php echo THEBUGGENIE_CORE_PATH; ?>templates/htaccess.template</i> file to <i>[main folder]/<?php echo THEBUGGENIE_PUBLIC_FOLDER_NAME; ?>/.htaccess</i></li>
                     <li>Open up the <i>[main folder]/<?php echo THEBUGGENIE_PUBLIC_FOLDER_NAME; ?>/.htaccess</i> file, and change the <u>RewriteBase</u> path to be identical to the <u>URL subdirectory</u></li>
-                    <li>If you're using PHP-FPM, rename or copy the <i><?php echo THEBUGGENIE_CORE_PATH; ?>templates/user.ini.template</i> file to <i>[main folder]/<?php echo THEBUGGENIE_PUBLIC_FOLDER_NAME; ?>/.user.ini</i></li>
                 </ul>
             </div>
         <?php elseif ($htaccess_ok): ?>
             <div class="ok">
-                Apache .htaccess and PHP-FPM .user.ini auto-setup completed successfully
+                Apache .htaccess auto-setup completed successfully
             </div>
         <?php endif; ?>
         <div class="ok">

--- a/core/modules/main/cli/Install.php
+++ b/core/modules/main/cli/Install.php
@@ -30,7 +30,7 @@
             $this->addOptionalArgument('url_subdir', 'Specify URL subdirectory');
             $this->addOptionalArgument('use_existing_db_info', 'Set to "yes" to use existing db information if available');
             $this->addOptionalArgument('enable_all_modules', 'Set to "yes" to install all modules');
-            $this->addOptionalArgument('setup_htaccess', 'Set to "yes" to autoconfigure .htaccess and .user.ini files');
+            $this->addOptionalArgument('setup_htaccess', 'Set to "yes" to autoconfigure .htaccess file');
         }
 
         public function do_execute()
@@ -291,14 +291,14 @@
 
                     if ($this->getProvidedArgument('setup_htaccess') != 'yes')
                     {
-                        $this->cliEcho("Setup can autoconfigure your .htaccess and .user.ini files (located in the public/ subfolder), so you don't have to.\n");
+                        $this->cliEcho("Setup can autoconfigure your .htaccess file (located in the public/ subfolder), so you don't have to.\n");
                         $this->cliEcho('Would you like setup to auto-generate those files for you?');
-                        $this->cliEcho("\nPress ENTER if ok, or \"no\" to not set up the .htaccess and .user.ini files: ");
+                        $this->cliEcho("\nPress ENTER if ok, or \"no\" to not set up the .htaccess file: ");
                         $htaccess_ok = $this->askToDecline();
                     }
                     else
                     {
-                        $this->cliEcho('Autoconfiguring .htaccess and .user.ini', 'yellow', 'bold');
+                        $this->cliEcho('Autoconfiguring .htaccess', 'yellow', 'bold');
                         $this->cliEcho("\n");
                         $htaccess_ok = true;
                     }
@@ -329,34 +329,10 @@
                                 $this->cliEcho("The .htaccess file was successfully set up...\n", 'green', 'bold');
                             }
                         }
-
-                    	if (!is_writable(THEBUGGENIE_PATH . 'public/') || (file_exists(THEBUGGENIE_PATH . 'public/.user.ini') && !is_writable(THEBUGGENIE_PATH . 'public/.user.ini')))
-                        {
-                            $this->cliEcho("Permission denied when trying to save the [main folder]/public/.user.ini\n", 'red', 'bold');
-                            $this->cliEcho("You will have to set up the .user.ini file yourself. See the README file for more information.\n", 'white', 'bold');
-                            $this->cliEcho('Please note: ', 'white', 'bold');
-                            $this->cliEcho("If you're using PHP-FPM, The Bug Genie might not function properly until the .user.ini file is properly set up\n");
-                        }
-                        else
-                        {
-                            $content = file_get_contents(THEBUGGENIE_CORE_PATH . 'templates/htaccess.template');
-                            file_put_contents(THEBUGGENIE_PATH . 'public/.user.ini', $content);
-                            if (file_get_contents(THEBUGGENIE_PATH . 'public/.user.ini') != $content)
-                            {
-                                $this->cliEcho("Permission denied when trying to save the [main folder]/public/.user.ini\n", 'red', 'bold');
-                                $this->cliEcho("You will have to set up the .user.ini file yourself. See the README file for more information.\n", 'white', 'bold');
-                                $this->cliEcho('Please note: ', 'white', 'bold');
-                                $this->cliEcho("If you're using PHP-FPM, The Bug Genie might not function properly until the .user.ini file is properly set up\n");
-                            }
-                            else
-                            {
-                                $this->cliEcho("The .user.ini file was successfully set up...\n", 'green', 'bold');
-                            }
-                        }
                     }
                     else
                     {
-                        $this->cliEcho("Skipping .htaccess and .user.ini auto-setup.");
+                        $this->cliEcho("Skipping .htaccess auto-setup.");
                     }
 
                     if ($this->getProvidedArgument('setup_htaccess') != 'yes')

--- a/core/templates/htaccess.template
+++ b/core/templates/htaccess.template
@@ -1,32 +1,37 @@
 # .htaccess file for The Bug Genie
 
-# make sure that magic_quotes and register_globals is always off
-<IfModule mod_php5.c>
-	php_flag magic_quotes_gpc	off
-	php_flag register_globals	off
-</IfModule>
-
-# Follow symlinks
+# Follow symlinks.
 Options +FollowSymlinks
 
-# rewrite rules
+# Apply rewrite rules for pretty URLs.
 <IfModule mod_rewrite.c>
-  RewriteEngine On
-  RewriteBase ###PUT URL SUBDIRECTORY HERE###
-# Example:
-# RewriteBase /
-# or
-# RewriteBase /dev/thebuggenie
+    RewriteEngine On
+    # If you have a non-typical set-up, you can set the RewriteBase in order to
+    # make sure that base URLs when generating rewritten URLs are set correctly.
+    #
+    # For example:
+    #
+    # Rewrite Base /
+    #
+    # Rewrite Base /dev/thebuggenie
+    #
+    RewriteBase ###PUT URL SUBDIRECTORY HERE###
 
-  RewriteCond %{REQUEST_FILENAME} -s [OR]
-  RewriteCond %{REQUEST_FILENAME} -l [OR]
-  RewriteCond %{REQUEST_FILENAME} -d
-  RewriteRule ^.*$ - [NC,L]
+    # Try serving a file (if non-zero size), file or directory pointed to by
+    # symlink, or directory directly. If so, serve that file/directory
+    # unmodified, and do not apply any further rewrite rules.
+    RewriteCond %{REQUEST_FILENAME} -s [OR]
+    RewriteCond %{REQUEST_FILENAME} -l [OR]
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^.*$ - [L]
 
-  # redirect to front controller
-  RewriteRule ^(.*)$ index.php?url=$1 [NC,QSA,L]
+    # Redirect any other request to front controller. Use case-insensitive
+    # matching, making sure to append any additional query strings
+    # passed-in. Once the rewrite has been done, do not apply any further
+    # rewrite rules.
+    RewriteRule ^(.*)$ index.php?url=$1 [NC,QSA,L]
 
 </IfModule>
 
-# Stop people accessing directories they shouldn't have access to
-RedirectMatch 403 ^/\.svn(/|$)
+# Prevent access to "hidden" files.
+RedirectMatch 404 ^/\..*$

--- a/core/templates/user.ini.template
+++ b/core/templates/user.ini.template
@@ -1,2 +1,0 @@
-magic_quotes_gpc=0
-register_globals=0

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,26 +1,37 @@
 # .htaccess file for The Bug Genie
 
-# make sure that magic_quotes and register_globals is always off
-<IfModule mod_php5.c>
-  php_flag magic_quotes_gpc off
-  php_flag register_globals off
-</IfModule>
+# Follow symlinks.
+Options +FollowSymlinks
 
-# rewrite rules
+# Apply rewrite rules for pretty URLs.
 <IfModule mod_rewrite.c>
     RewriteEngine On
-
-    # Examples:
-    # RewriteBase /public
-    # RewriteBase /thebuggenie/public
+    # If you have a non-typical set-up, you can set the RewriteBase in order to
+    # make sure that base URLs when generating rewritten URLs are set correctly.
+    #
+    # For example:
+    #
+    # Rewrite Base /
+    #
+    # Rewrite Base /dev/thebuggenie
+    #
     RewriteBase /
 
-    RewriteCond %{REQUEST_FILENAME} -f
-    RewriteRule .? - [L]
+    # Try serving a file (if non-zero size), file or directory pointed to by
+    # symlink, or directory directly. If so, serve that file/directory
+    # unmodified, and do not apply any further rewrite rules.
+    RewriteCond %{REQUEST_FILENAME} -s [OR]
+    RewriteCond %{REQUEST_FILENAME} -l [OR]
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^.*$ - [L]
 
-    # redirect to front controller
+    # Redirect any other request to front controller. Use case-insensitive
+    # matching, making sure to append any additional query strings
+    # passed-in. Once the rewrite has been done, do not apply any further
+    # rewrite rules.
     RewriteRule ^(.*)$ index.php?url=$1 [NC,QSA,L]
+
 </IfModule>
 
-# Stop people accessing directories they shouldn't have access to
-RedirectMatch 403 ^/\.svn(/|$)
+# Prevent access to "hidden" files.
+RedirectMatch 404 ^/\..*$


### PR DESCRIPTION
The purpose of this pull request is to improve how the .htaccess is handled, making the template look identical to stock .htaccess shipped and to remove deployment of deprecated PHP options in .htaccess and .user.ini.

Having the .htaccess file harmonised helps with avoiding accidental git commits (assuming that most people working on TBG will use RewriteBase of /).

The following two options are removed from `.user.ini` (technically, whole file is removed since these are the only options it had) and `.htaccess`:

- magic_quotes_gpc
- register_globals

According to documentation at http://php.net/manual/en/security.magicquotes.what.php and http://php.net/manual/en/security.globals.php these two features have been completely removed in PHP 5.4.0 and have been marked as deprecated in PHP 5.3.0.

As of this writing, the `core/bootstrap.php` file has explicit check for the PHP version used, and states:

```
This software requires PHP 5.4.0 or newer. Please upgrade to a newer version of php to use The Bug Genie.
```

Therefore it makes sense to remove those options to reduce cruft.