### PR TITLE
Git hook fixes

### DIFF
--- a/modules/vcs_integration/hooks/git/tbg-post-receive
+++ b/modules/vcs_integration/hooks/git/tbg-post-receive
@@ -45,7 +45,7 @@ update_tbg()
         name=`git show --no-patch --format="%an <%ae>" $commithash`
         log=`git show --no-patch --format="%s %b" $commithash`
         time=`git show --no-patch --format="%ct" $commithash`
-        changedfiles=`git diff-tree --name-status -r $newhash --no-commit-id`
+        changedfiles=`git diff-tree --name-status -r $commithash --no-commit-id`
 
         #echo "updating with name: $name"
         #echo "updating with log: $log"

--- a/modules/vcs_integration/hooks/git/tbg-post-receive
+++ b/modules/vcs_integration/hooks/git/tbg-post-receive
@@ -23,7 +23,7 @@ update_tbg()
     refname=$3
 
     # Not working? uncomment the echos and see what's not arriving properly
-    echo "Attempting to update tbg with oldhash: $oldhash newhash: $newhash refname: $refname"
+    #echo "Attempting to update tbg with oldhash: $oldhash newhash: $newhash refname: $refname"
 
     # Ignore tag pushes
     if [[ "$refname" == "refs/tags/"* ]]; then
@@ -38,7 +38,7 @@ update_tbg()
     # Loop through all commits
     echo "$commitlist" | while read -r commithash
     do
-        echo "Update tbg with commit: $commithash"
+        #echo "Update tbg with commit: $commithash"
 
         # Retrieve commit specific information.
         parrent=`git show --no-patch --format="%P" $commithash`

--- a/modules/vcs_integration/hooks/git/tbg-post-receive
+++ b/modules/vcs_integration/hooks/git/tbg-post-receive
@@ -23,29 +23,37 @@ update_tbg()
     refname=$3
 
     # Not working? uncomment the echos and see what's not arriving properly
-
     #echo "Attempting to update tbg with oldhash:$oldhash newhash:$newhash"
-    changedfiles=`git diff-tree --name-status -r $newhash --no-commit-id`
 
-    # Retrieve name, log, and time. Make sure to use correct syntax for the
-    # first commit of repository (where there's no parent/oldrev).
+    # If no oldhash is defined then we assume we only have one commit to process
     if [ "$oldhash" = "0000000000000000000000000000000000000000" ]; then
-        name=`git log $newhash --pretty=format:"%an <%ae>"`
-        log=`git log $newhash --pretty=format:"%s %b"`
-        time=`git log $newhash --pretty=format:"%ct"`
+        commitlist="${newhash}"
     else
-        name=`git log ^$oldhash $newhash --pretty=format:"%an <%ae>"`
-        log=`git log ^$oldhash $newhash --pretty=format:"%s %b"`
-        time=`git log ^$oldhash $newhash --pretty=format:"%ct"`
+        commitlist=`git rev-list ${oldhash}..${newhash}`
     fi
 
-    #echo "updating with name: $name"
-    #echo "updating with log: $log"
-    #echo "updating with time: $time"
-    #echo "updating files: $changedfiles"
+    # Loop through all commits
+    echo "$commitlist" | while read -r commithash
+    do
+        #echo "Update tbg with commit:$commithash"
 
-    cd $tbg_cli_path
-    ./tbg_cli vcs_integration:report_commit $projectid "$name" $newhash "$log" "$changedfiles" $oldhash $time
+        # Retrieve commit specific information.
+        parrent=`git show --no-patch --format="%P" $commithash`
+        name=`git show --no-patch --format="%an <%ae>" $commithash`
+        log=`git show --no-patch --format="%s %b" $commithash`
+        time=`git show --no-patch --format="%ct" $commithash`
+        changedfiles=`git diff-tree --name-status -r $newhash --no-commit-id`
+
+        #echo "updating with name: $name"
+        #echo "updating with log: $log"
+        #echo "updating with time: $time"
+        #echo "updating files: $changedfiles"
+
+        # Report commit to TBG
+        cd $tbg_cli_path
+        ./tbg_cli vcs_integration:report_commit $projectid "$name" $commithash "$log" "$changedfiles" $parrent $time $refname
+        cd - > /dev/null # back to git repo folder
+    done
 }
 
 if [ -n "$1" -a -n "$2" ]; then
@@ -58,5 +66,4 @@ else
         update_tbg $oldhash $newhash $refname
     done
 fi
-
 

--- a/modules/vcs_integration/hooks/git/tbg-post-receive
+++ b/modules/vcs_integration/hooks/git/tbg-post-receive
@@ -1,14 +1,14 @@
-#!/bin/sh
+#!/bin/bash
+
 # TheBugGenie post-receive hook for git, for direct access (git and tbg on same machine)
-# To use, this needs to be marked executable, and linked in to your git repo,
-# user@server:/path/to/repo/.git/hooks $ 
-#   ln -s /tbg_install/modules/vcs_integration/hooks/git/tbg-post-receive post-receive
-#   chmod +x /tbg_install/modules/vcs_integration/hooks/git/tbg-post-receive
+# To use, this needs to be marked executable, and copied into your git repo,
+# user@server:/path/to/repo/.git/hooks $
+#   cp /tbg_install/modules/vcs_integration/hooks/git/tbg-post-receive post-receive
+#   chmod +x ./post-receive
 
 #>>>>> User config
 
-# projectid comes from http://tbg_server/configure/module/vcs_integration
-# on the project settings tab
+# projectid comes from Project Settings -> VCS Integration
 projectid=1
 
 # this is the path to the installed thebuggenie.
@@ -23,11 +23,14 @@ update_tbg()
     refname=$3
 
     # Not working? uncomment the echos and see what's not arriving properly
-    #echo "Attempting to update tbg with oldhash:$oldhash newhash:$newhash"
+    echo "Attempting to update tbg with oldhash: $oldhash newhash: $newhash refname: $refname"
 
-    # If no oldhash is defined then we assume we only have one commit to process
-    if [ "$oldhash" = "0000000000000000000000000000000000000000" ]; then
-        commitlist="${newhash}"
+    # Ignore tag pushes
+    if [[ "$refname" == "refs/tags/"* ]]; then
+        return
+    # If no previous hash is defined then we assume this is the first commit, so process all previous commits
+    elif [[ "$oldhash" == "0000000000000000000000000000000000000000" ]]; then
+        commitlist=`git rev-list ${newhash}`
     else
         commitlist=`git rev-list ${oldhash}..${newhash}`
     fi
@@ -35,7 +38,7 @@ update_tbg()
     # Loop through all commits
     echo "$commitlist" | while read -r commithash
     do
-        #echo "Update tbg with commit:$commithash"
+        echo "Update tbg with commit: $commithash"
 
         # Retrieve commit specific information.
         parrent=`git show --no-patch --format="%P" $commithash`
@@ -66,4 +69,5 @@ else
         update_tbg $oldhash $newhash $refname
     done
 fi
+
 


### PR DESCRIPTION
I've fixed some issues  with the bundled git hook from TBG.

- The new script separates each commit in a push and reports them individually to tbg_cli. 
- It now includes the branch name/ref when calling tbg_cli
- Ignores tags, as it would go through all commits in the repo

I think these changes fixes issue #603 and issue #2111