### PR TITLE
Removed 'float' on CSS for description and step headers

### DIFF
--- a/themes/oxygen/css/theme.css
+++ b/themes/oxygen/css/theme.css
@@ -17699,13 +17699,6 @@ li[id^='transition_popup_assignee_div_'] div[id^='popup_assigned_to_name_indicat
 }
 
 #issue_main #description_header,
-#issue_main #description_content,
-#issue_main #reproduction_steps_header,
-#issue_main #reproduction_steps_content {
-    float: left;
-}
-
-#issue_main #description_header,
 #issue_main #reproduction_steps_header {
     padding-top: 0;
 }


### PR DESCRIPTION
The sections 'Description' and 'Steps to reproduce this issue' are
misplaced: the headers are not shown at all and the content is moved on
the right part of the screen. Removing 'float: left' from the CSS of
those headers and contents, the problem is resolved.