### PR TITLE
Fix for milestones where all issues are closed/resolved, but they still appear as overdue

### DIFF
--- a/core/framework/Settings.php
+++ b/core/framework/Settings.php
@@ -150,7 +150,7 @@
 
         protected static $_ver_mj = 4;
         protected static $_ver_mn = 1;
-        protected static $_ver_rev = 13;
+        protected static $_ver_rev = 14;
         protected static $_ver_name = "Blissful Banana";
         protected static $_defaultscope = null;
         protected static $_settings = null;

--- a/core/modules/installation/Upgrade.php
+++ b/core/modules/installation/Upgrade.php
@@ -180,6 +180,30 @@ class Upgrade
         }
     }
 
+    protected function _upgradeFrom4dot1dot13()
+    {
+        set_time_limit(0);
+
+        if (defined('TBG_CLI')) {
+            framework\cli\Command::cli_echo("Updating/fixing status of milestones.\n");
+        }
+
+        $milestones = \thebuggenie\core\entities\tables\Milestones::getTable()->selectAll();
+
+        foreach ($milestones as $milestone)
+        {
+            $milestone->updateStatus();
+            $milestone->save();
+        }
+
+        $this->upgrade_complete = true;
+        $this->current_version = '4.1.14';
+
+        if (defined('TBG_CLI')) {
+            framework\cli\Command::cli_echo("Successfully upgraded to version {$this->current_version}\n");
+        }
+    }
+
     public function upgrade()
     {
         list ($this->current_version, $this->upgrade_available) = framework\Settings::getUpgradeStatus();
@@ -222,6 +246,8 @@ class Upgrade
                     $this->_upgradeFrom4dot1dot11();
                 case '4.1.12':
                     $this->_upgradeFrom4dot1dot12();
+                case '4.1.13':
+                    $this->_upgradeFrom4dot1dot13();
                 default:
                     $this->upgrade_complete = true;
                     break;


### PR DESCRIPTION
This pull request should fix the issue with finished milestones (all issues closed/resolved) that are still shown as overdue.

The pull request also touches slightly on the code for updating related issues in sprints. This has not been tested, though - if you happen to be able to do it and review it, that'd help greatly. Otherwise feel free to nudge me into checking it out myself - but I haven't worked with sprints that much :)

There is also upgrade code that will try to fix existing overdue milestones by forcing a status update on them. I bumped the version to 4.1.14, but not sure if it should be some other version in there (since we discussed earlier bumping to 4.2 due to previous big changes to permission check implementation).