### PR TITLE
Features 2, 3 (list of contributions), and 4 (distinct missing page links) from issue #610

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ apache-error.log
 
 # Ignore coverage report
 coverage-report
+
+# Ignore GNU Global tag files.
+GPATH
+GRTAGS
+GTAGS

--- a/core/helpers/Pagination.php
+++ b/core/helpers/Pagination.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace thebuggenie\core\helpers;
+
+/**
+ * Helper class that deals with pagination.
+ *
+ * @author Branko Majic <branko@majic.rs>
+ * @version 4.2
+ * @license http://opensource.org/licenses/MPL-2.0 Mozilla Public License 2.0 (MPL 2.0)
+ * @package thebuggenie
+ * @subpackage main
+ */
+
+
+/**
+ * Helper class that deals with pagination. Provides the following features:
+ *
+ * - Processes request to extract pagination arguments.
+ * - Calculates what items should be part of the current (requested) page.
+ * - Calculates pagination URLs.
+ * - Supports multiple page sizes.
+ * - Comes with special template for rendering the pagination elements in
+ *   consistent manner.
+ *
+ * To use it, first you would add something similar to the following in your
+ * controller code:
+ *
+ * // Parameters you need for initialising Pagination instance
+ * // ($extra_get_parameters are optional).
+ * $request = framework\Context::getRequest();
+ * $my_items = your_function_that_grabs_items_in_an_array();
+ * $base_url = "/someurl";
+ * $extra_get_parameters = ['something1' => 'somevalue1', 'something2' => 'somevalue2'];
+ *
+ * $pagination = new Pagination($my_items, $base_url, $request, $extra_get_parameters);
+ *
+ * // Set-up the tempalte context.
+ * $this->my_items = $pagination->getPageItems();
+ * $this->pagination = $pagination;
+ *
+ * With that out of the way, you can do something like this in the template:
+ *
+ * <?php foreach ($my_items as $my_item): ?>
+ *   do something with $my_item
+ * <?php endforeach ?>
+ * <?php include_component('main/pagination', ['pagination' => $pagination]); ?>
+ *
+ */
+class Pagination
+{
+    /**
+     * Default page to show in case the request did not specify a page.
+     *
+     */
+    const DEFAULT_PAGE = 1;
+
+    /**
+     * Default page size to use when displaying results.
+     *
+     */
+    const DEFAULT_PAGE_SIZE = 20;
+
+    /**
+     * Available page sizes.
+     *
+     */
+    const AVAILABLE_PAGE_SIZES = [20, 50, 100, 250, 500];
+
+    /**
+     * Maximum number of page URLs to display in pagination. The limit excludes
+     * special links for first, previous, next, and last page.
+     *
+     */
+    const PAGE_URL_LIMIT = 10;
+
+
+    /**
+     * Array containing all elements that should be included in pagination
+     * calculation. Passed-in by the user.
+     *
+     */
+    protected $_items;
+
+    /**
+     * Base URL passed-in by the user for calculating pagination URLs.
+     *
+     */
+    protected $_base_url;
+
+    /**
+     * Requested page.
+     *
+     */
+    protected $_page;
+
+    /**
+     * Requested page size.
+     *
+     */
+    protected $_page_size;
+
+    /**
+     * Additional GET parameters to include in the URL generation.
+     *
+     */
+    protected $_extra_get_parameters;
+
+    /**
+     * Prefix to use on top of base URL when generating navigation URLs. Used as
+     * convenience property to avoid complicated logic for avoding duplicate '?'
+     * and '&' characters in generated URLs.
+     *
+     */
+    protected $_base_url_extra_parameter_prefix;
+
+    /**
+     * Initialises instance, storing passed-in parameters, and ensuring
+     * passed-in values via requests object are valid.
+     *
+     * @param array $items
+     *   Array with all the elements that should be taken into consideration for
+     *   pagination.
+     *
+     * @param string $base_url
+     *   Base URL for generating the pagination URLs. This should be a plain
+     *   link - any GET parameters should be passed-in as part of
+     *   $extra_get_parameters.
+     *
+     * @param \thebuggenie\core\framework\Request $request
+     *   Original request object received by the code. The request object is
+     *   used to extract information about the page number and page size. The
+     *   following parameters are extracted from it: 'page' and 'page_size'.
+     *
+     * @param array $extra_get_parameters
+     *   Additional set of GET parameters to include in generated navigation
+     *   URLs. This should be a hash where both keys and values are
+     *   strings. Keys 'page' and 'page_size' will be stripped from the array,
+     *   while keys with null value will be ignored.
+     *
+     */
+    function __construct($items, $base_url, $request, $extra_get_parameters = [])
+    {
+        // Store parameters passed-in by the user.
+        $this->_items = $items;
+        $this->_base_url = $base_url;
+        $this->_extra_get_parameters = $extra_get_parameters;
+
+        // Process user-supplied GET parameters to get them in key=value format.
+        $get_parameters = [];
+        foreach ($this->_extra_get_parameters as $parameter => $value)
+        {
+            if ($value !== null && $parameter != 'page' && $parameter != 'page_size')
+            {
+                $get_parameters[] = "${parameter}=${value}";
+            }
+        }
+
+        // Determine the extra parameter prefix (this gets appended to base_url
+        // before pagination GET parameters).
+        if (count($get_parameters) > 0)
+        {
+            $this->_base_url_extra_parameter_prefix = "?" . implode("&", $get_parameters) . "&";
+        }
+        else
+        {
+            $this->_base_url_extra_parameter_prefix = "?";
+        }
+
+        // Extract the page number and page size from request.
+        $this->_page = intval($request->getParameter('page'));
+        $this->_page_size = intval($request->getParameter('page_size'));
+
+        // Ensure page and page size are valid non-negative integer values.
+        if ($this->_page < 1)
+        {
+            $this->_page = self::DEFAULT_PAGE;
+        }
+
+        if ($this->_page_size < 1)
+        {
+            $this->_page_size = self::DEFAULT_PAGE_SIZE;
+        }
+
+        // Ensure we are not out of bounds with page number.
+        if ($this->_page > $this->getTotalPages())
+        {
+            $this->_page = $this->getTotalPages();
+        }
+    }
+
+    /**
+     * Returns total number of pages based on page size and number of elements.
+     *
+     *
+     * @return int
+     */
+    public function getTotalPages()
+    {
+        return ceil(count($this->_items) / $this->_page_size);
+    }
+
+    /**
+     * Returns an array containing all items that belong to requested page.
+     *
+     *
+     * @return array
+     */
+    public function getPageItems()
+    {
+        return array_slice($this->_items,
+                           ($this->_page - 1) * $this->_page_size,
+                           ($this->_page - 1) * $this->_page_size + $this->_page_size);
+    }
+
+    /**
+     * Calculates page URLs.
+     *
+     *
+     * @retval array
+     *   Page URLs. Each URL is represented by an array of its own, with the
+     *   following keys:
+     *
+     *   text
+     *     Text to display to user for the page. This will be either a number,
+     *     or a special character for denoting link to first ('&larrb;'),
+     *     previous ('&laquo;'), next ('&raquo;'), or last ('&rarrb;') page.
+     *
+     *   hint
+     *     Hint shown on mouse-over. If not one of the links for first,
+     *     previous, next, or last pages, value will be null.
+     *
+     *   url
+     *     URL to reach the page. If page number is equal to requested page,
+     *     value will be null.
+     */
+    public function getPageURLs()
+    {
+        // Calculate the left and right boundary first, using the requested page
+        // number as approximate middle.
+        $left = $this->_page - floor((self::PAGE_URL_LIMIT-1)/2);
+        $right = $this->_page + ceil((self::PAGE_URL_LIMIT-1)/2);
+
+        // If either left or right boundary exceeds total number of pages, shift
+        // the other one by the exceeded number.
+        if ($left < 1)
+        {
+            $right = $right + (1 - $left);
+        }
+
+        if ($right > $this->getTotalPages())
+        {
+            $left = $left - ($right - $this->getTotalPages());
+        }
+
+        // Once shifting is done, make sure the left and right boundaries are
+        // not invalid.
+        if ($left < 1)
+        {
+            $left = 1;
+        }
+
+        if ($right > $this->getTotalPages())
+        {
+            $right = $this->getTotalPages();
+        }
+
+        // Array for storing all pagination URLs.
+        $pagination_urls = [];
+
+        // Pagination base URL.
+        $pagination_url_base = $this->_base_url . $this->_base_url_extra_parameter_prefix . ($this->_page_size != self::DEFAULT_PAGE_SIZE ? "page_size={$this->_page_size}&" : "");
+
+        // Add the first/previous page URLs.
+        if ($left != 1)
+        {
+            $pagination_urls[] = ['text' => '&larrb;',
+                                  'hint' => 'First page',
+                                  'url'  => "{$pagination_url_base}page=1"];
+
+            $pagination_urls[] = ['text' => '&laquo;',
+                                  'hint' => 'Previous page',
+                                  'url'  => "{$pagination_url_base}page=" . ($this->_page-1)];
+        }
+
+        // Process all "numeric" links.
+        for ($i = $left; $i <= $right; $i++)
+        {
+            $pagination_urls[] = ['text' => $i,
+                                  'hint' => ($i == $this->_page ? "Current page" : null),
+                                  'url'  => ($i == $this->_page ? null : "{$pagination_url_base}page={$i}")];
+        }
+
+        // Add the next/last page URLs.
+        if ($right != $this->getTotalPages())
+        {
+            $pagination_urls[] = ['text' => '&raquo;',
+                                  'hint' => 'Next page',
+                                  'url'  => "{$pagination_url_base}page=" . ($this->_page+1)];
+
+            $pagination_urls[] = ['text' => '&rarrb;',
+                                  'hint' => 'Last page',
+                                  'url'  => "{$pagination_url_base}page=" . $this->getTotalPages()];
+        }
+
+        return $pagination_urls;
+    }
+
+    /**
+     * Calculates page size URLs.
+     *
+     *
+     * @retval array
+     *
+     *   Page size URLs. Each URL is represented by an array of its own, with
+     *   the following keys:
+     *
+     *   text
+     *     Text to display to user for the page size.
+     *
+     *   hint
+     *     Hint shown on mouse-over.
+     *
+     *   url
+     *     URL to switch the page size. If page size is equal to requested page
+     *     size, value will be null.
+     */
+    public function getPageSizeURLs()
+    {
+        // Store all page size URLs within this variable.
+        $page_size_urls = [];
+
+        // Pagination base URL.
+        $pagination_url_base = $this->_base_url . $this->_base_url_extra_parameter_prefix;
+
+        foreach (self::AVAILABLE_PAGE_SIZES as $page_size)
+        {
+            $page_size_urls[] = ['text' => $page_size,
+                                 'hint' => "Page size",
+                                 'url'  => ($page_size == $this->_page_size ? null : "{$pagination_url_base}page_size={$page_size}")];
+        }
+
+        return $page_size_urls;
+    }
+}

--- a/core/helpers/TextParser.php
+++ b/core/helpers/TextParser.php
@@ -363,7 +363,7 @@
 
             // Additional options to set in the tag (i.e. for specifying CSS
             // class etc).
-            $href_options = array();
+            $href_options = [];
 
             if (isset($matches[6]) && $matches[6])
             {

--- a/core/helpers/TextParser.php
+++ b/core/helpers/TextParser.php
@@ -361,6 +361,10 @@
         {
             $href = html_entity_decode($matches[4], ENT_QUOTES, 'UTF-8');
 
+            // Additional options to set in the tag (i.e. for specifying CSS
+            // class etc).
+            $href_options = array();
+
             if (isset($matches[6]) && $matches[6])
             {
                 $title = $matches[6];
@@ -598,7 +602,12 @@
 
                 if (framework\Context::isCLI()) return $href;
 
-                $href = framework\Context::getRouting()->generate('publish_article', array('article_name' => $href));
+                if (!Article::doesArticleExist($href))
+                {
+                    $href_options['class'] = 'missing_wiki_page';
+                }
+
+                $href = framework\Context::getRouting()->generate('publish_article', array('article_name' => $href), $href_options);
             }
             else
             {
@@ -607,7 +616,7 @@
 
             if (framework\Context::isCLI()) return $href;
 
-            return link_tag($href, $title);
+            return link_tag($href, $title, $href_options);
         }
 
         protected function _parse_externallink($matches)

--- a/core/helpers/TextParser.php
+++ b/core/helpers/TextParser.php
@@ -607,7 +607,7 @@
                     $href_options['class'] = 'missing_wiki_page';
                 }
 
-                $href = framework\Context::getRouting()->generate('publish_article', array('article_name' => $href), $href_options);
+                $href = framework\Context::getRouting()->generate('publish_article', array('article_name' => $href));
             }
             else
             {

--- a/core/modules/main/templates/_pagination.inc.php
+++ b/core/modules/main/templates/_pagination.inc.php
@@ -1,0 +1,22 @@
+<div class="paginator">
+    <div class="pages">
+        <?php foreach ($pagination->getPageURLs() as $page_url): ?>
+            <?php $page_url_classes = ($page_url['url'] === null ? 'button button-silver disabled' : 'button button-silver'); ?>
+            <?php if ($page_url['url'] === null): ?>
+                <a class="<?= $page_url_classes ?>"><?= $page_url['text']?></a>
+            <?php else: ?>
+                <?= link_tag($page_url['url'], $page_url['text'], ['class' => $page_url_classes, 'title' => $page_url['hint']]); ?>
+            <?php endif ?>
+        <?php endforeach ?>
+    </div>
+    <div class="page_sizes">
+        <?php foreach ($pagination->getPageSizeURLs() as $page_size_url): ?>
+            <?php $page_size_url_classes = ($page_size_url['url'] === null ? 'button button-silver disabled' : 'button button-silver'); ?>
+            <?php if ($page_size_url['url'] === null): ?>
+                <a class="<?= $page_size_url_classes ?>"><?= $page_size_url['text']?></a>
+            <?php else: ?>
+                <?= link_tag($page_size_url['url'], $page_size_url['text'], ['class' => $page_size_url_classes, 'title' => $page_size_url['hint']]); ?>
+            <?php endif ?>
+        <?php endforeach ?>
+    </div>
+</div>

--- a/modules/publish/Components.php
+++ b/modules/publish/Components.php
@@ -139,7 +139,7 @@
             $request = framework\Context::getRequest();
             $current_project = framework\Context::getCurrentProject();
 
-            $available_page_sizes = array(20, 50, 100, 250, 500);
+            $available_page_sizes = [20, 50, 100, 250, 500];
             $default_page_size = 50;
             $default_page = 1;
 
@@ -208,10 +208,10 @@
                                          ($page - 1) * $page_size + $page_size);
 
             // Calculate pagination URLs.
-            $navigation_urls = array();
-            $page_size_urls = array();
+            $navigation_urls = [];
+            $page_size_urls = [];
 
-            $base_url = make_url('publish_article', array('article_name' => "Special:{$this->projectnamespace}Contributions"));
+            $base_url = make_url('publish_article', ['article_name' => "Special:{$this->projectnamespace}Contributions"]);
             $base_url_user_prefix = ($username !== null ? "?user={$username}&" : '?');
             $navigation_url_base = $base_url . $base_url_user_prefix . ($page_size != $default_page_size ? 'page_size=' . $page_size : '');
 
@@ -247,6 +247,6 @@
             $user_ids = ArticleHistory::getTable()->getContributorIDsByProject($current_project);
 
             $this->contributors = Users::getTable()->getByUserIDs($user_ids);
-            $this->contributions_base_url = make_url('publish_article', array('article_name' => "Special:{$this->projectnamespace}Contributions"));
+            $this->contributions_base_url = make_url('publish_article', ['article_name' => "Special:{$this->projectnamespace}Contributions"]);
         }
     }

--- a/modules/publish/Components.php
+++ b/modules/publish/Components.php
@@ -143,85 +143,44 @@
             $default_page_size = 50;
             $default_page = 1;
 
+            //Author ID associated with articles created automatically during
+            //installation.
+            $fixtures_user = 0;
+
             $username = $request->getParameter('user');
             $page_size = ceil($request->getParameter('page_size', $default_page_size));
             $page = floor($request->getParameter('page', $default_page));
 
-            // All contributions made by the user will be stored within this
-            // array.
-            $contributions = array();
-
-            // Fetch user (if any was passed-in).
-            $user = Users::getTable()->getByUsername($username);
-
-            // Calculate base URL and base URL user prefix. Prefix is used to
-            // avoid extra ? or & signs).
-            $base_url = make_url('publish_article', array('article_name' => "Special:{$this->projectnamespace}Contributions"));
-            $base_url_user_prefix = ($user !== null ? "?user={$username}&" : '?');
-
-            // Fetch history based on user.
-            $history = ArticleHistory::getTable()->getByUser($user);
-
-            if ($history)
+            // Determine full username and whether the user is invalid or not.
+            if ($username === "")
             {
-                // Contributions by the user will be stored in this specific array.
-                $contributions = array();
-
-                while ($row = $history->getNextRow())
+                $invalid_user = false;
+                $user = null;
+                $user_full_name = null;
+            }
+            elseif ($username === null)
+            {
+                $invalid_user = false;
+                $user = null;
+                $user_full_name = null;
+            }
+            else
+            {
+                $user = Users::getTable()->getByUsername($username);
+                if ($user === null)
                 {
-                    // Extract basic information.
-                    $date = $row[ArticleHistory::DATE];
-                    $revision = $row[ArticleHistory::REVISION];
-                    $article_name = $row[ArticleHistory::ARTICLE_NAME];
-                    $reason = $row[ArticleHistory::REASON];
-                    $author_id = $row[ArticleHistory::AUTHOR];
-                    $author = Users::getTable()->getByUserID($author_id);
-                    if ($author === null)
-                    {
-                        $author_contributions_url = null;
-                    }
-                    else
-                    {
-                        $author_contributions_url = "{$base_url}?user={$author->getUsername()}";
-                    }
-
-                    // Ignore articles the currently logged-in user can't read
-                    // and those that are not part of current project.
-                    $article = Article::getByName($article_name);
-                    if (!$article->hasAccess() || $article->getProject() != $current_project)
-                    {
-                        continue;
-                    }
-
-                        // Calculated properties, primarily URLs.
-                    $revision_url = make_url('publish_article_revision', array('article_name' => $article_name,
-                                                                               'revision' => $revision));
-                    $article_url = make_url('publish_article', array('article_name' => $article_name));
-                    if ($revision > 1)
-                    {
-                        $diff_url = make_url('publish_article_diff', array('article_name' => $article_name,
-                                                                           'from_revision' => $revision-1,
-                                                                           'to_revision' => $revision));
-                    }
-                    else
-                    {
-                        $diff_url = null;
-                    }
-                    $history_url = make_url('publish_article_history', array('article_name' => $article_name));
-
-                    // Add contribution for consumption in template.
-                    $contributions[] = array('date' => $date,
-                                             'revision' => $revision,
-                                             'article_name' => $article_name,
-                                             'reason' => $reason,
-                                             'author' => $author,
-                                             'author_contributions_url' => $author_contributions_url,
-                                             'revision_url' => $revision_url,
-                                             'article_url' => $article_url,
-                                             'diff_url' => $diff_url,
-                                             'history_url' => $history_url);
+                    $invalid_user = true;
+                    $user_full_name = null;
+                }
+                else
+                {
+                    $invalid_user = false;
+                    $user_full_name = $user->getNameWithUsername();
                 }
             }
+
+            // Grab author contributions with current user's access rights in mind.
+            $contributions = ArticleHistory::getTable()->getByAuthorUsernameAndCurrentUserAccess($username);
 
             // Ensure the page size is a valid value (has to be whole number greated than 0).
             if ($page_size < 1 )
@@ -243,20 +202,17 @@
                 $page = $default_page;
             }
 
-            // Determine starting and ending contribution that fits on this specific page.
-            $page_start_at = ($page - 1) * $page_size;
-            $page_end_at = ($page - 1) * $page_size + $page_size - 1;
-
-            // Make sure we don't go past the last contribution.
-            if ($page_end_at > $contributions_size - 1)
-            {
-                $page_end_at = $contributions_size - 1;
-            }
+            // Narrow down list of contributions to current page.
+            $contributions = array_slice($contributions,
+                                         ($page - 1) * $page_size,
+                                         ($page - 1) * $page_size + $page_size);
 
             // Calculate pagination URLs.
             $navigation_urls = array();
             $page_size_urls = array();
 
+            $base_url = make_url('publish_article', array('article_name' => "Special:{$this->projectnamespace}Contributions"));
+            $base_url_user_prefix = ($username !== null ? "?user={$username}&" : '?');
             $navigation_url_base = $base_url . $base_url_user_prefix . ($page_size != $default_page_size ? 'page_size=' . $page_size : '');
 
             $navigation_urls['newest'] = $navigation_url_base . '&page=' . '1';
@@ -272,13 +228,13 @@
             // Prepare context for template.
             $this->username = $username;
             $this->user = $user;
+            $this->user_full_name = $user_full_name;
+            $this->invalid_user = $invalid_user;
             $this->contributions = $contributions;
 
             $this->page = $page;
             $this->total_pages = $total_pages;
             $this->page_size = $page_size;
-            $this->page_start_at = $page_start_at;
-            $this->page_end_at = $page_end_at;
             $this->navigation_urls = $navigation_urls;
             $this->page_size_urls = $page_size_urls;
             $this->available_page_sizes = $available_page_sizes;

--- a/modules/publish/Components.php
+++ b/modules/publish/Components.php
@@ -151,137 +151,136 @@
             // array.
             $contributions = array();
 
-            // Try to get the user based on passed ID, or use currently
-            // logged-in user if not provided.
-            if ($username !== null)
-            {
-                $user = Users::getTable()->getByUsername($username);
-            }
-            else
-            {
-                $user = framework\Context::getUser();
-            }
+            // Fetch user (if any was passed-in).
+            $user = Users::getTable()->getByUsername($username);
 
-            if ($user !== null)
-            {
-                $history = ArticleHistory::getTable()->getByUser($user);
+            // Calculate base URL and base URL user prefix. Prefix is used to
+            // avoid extra ? or & signs).
+            $base_url = make_url('publish_article', array('article_name' => "Special:{$this->projectnamespace}Contributions"));
+            $base_url_user_prefix = ($user !== null ? "?user={$username}&" : '?');
 
-                if ($history)
+            // Fetch history based on user.
+            $history = ArticleHistory::getTable()->getByUser($user);
+
+            if ($history)
+            {
+                // Contributions by the user will be stored in this specific array.
+                $contributions = array();
+
+                while ($row = $history->getNextRow())
                 {
-                    // Contributions by the user will be stored in this specific array.
-                    $contributions = array();
-
-                    while ($row = $history->getNextRow())
+                    // Extract basic information.
+                    $date = $row[ArticleHistory::DATE];
+                    $revision = $row[ArticleHistory::REVISION];
+                    $article_name = $row[ArticleHistory::ARTICLE_NAME];
+                    $reason = $row[ArticleHistory::REASON];
+                    $author_id = $row[ArticleHistory::AUTHOR];
+                    $author = Users::getTable()->getByUserID($author_id);
+                    if ($author === null)
                     {
-                        // Extract basic information.
-                        $date = $row[ArticleHistory::DATE];
-                        $revision = $row[ArticleHistory::REVISION];
-                        $article_name = $row[ArticleHistory::ARTICLE_NAME];
-                        $reason = $row[ArticleHistory::REASON];
-                        $author = $row[ArticleHistory::AUTHOR];
+                        $author_contributions_url = null;
+                    }
+                    else
+                    {
+                        $author_contributions_url = "{$base_url}?user={$author->getUsername()}";
+                    }
 
-                        // Ignore articles the currently logged-in user can't read.
-                        $article = Article::getByName($article_name);
-                        if (!$article->canRead() || $article->getProject() != $current_project)
-                        {
-                            continue;
-                        }
+                    // Ignore articles the currently logged-in user can't read.
+                    $article = Article::getByName($article_name);
+                    if (!$article->canRead() || $article->getProject() != $current_project)
+                    {
+                        continue;
+                    }
 
                         // Calculated properties, primarily URLs.
-                        $revision_url = make_url('publish_article_revision', array('article_name' => $article_name,
-                                                                                   'revision' => $revision));
-                        $article_url = make_url('publish_article', array('article_name' => $article_name));
-                        if ($revision > 1)
-                        {
-                            $diff_url = make_url('publish_article_diff', array('article_name' => $article_name,
-                                                                               'from_revision' => $revision-1,
-                                                                               'to_revision' => $revision));
-                        }
-                        else
-                        {
-                            $diff_url = null;
-                        }
-                        $history_url = make_url('publish_article_history', array('article_name' => $article_name));
-
-                        // Add contribution for consumption in template.
-                        $contributions[] = array('date' => $date,
-                                                 'revision' => $revision,
-                                                 'article_name' => $article_name,
-                                                 'reason' => $reason,
-                                                 'author' => $author,
-                                                 'revision_url' => $revision_url,
-                                                 'article_url' => $article_url,
-                                                 'diff_url' => $diff_url,
-                                                 'history_url' => $history_url);
+                    $revision_url = make_url('publish_article_revision', array('article_name' => $article_name,
+                                                                               'revision' => $revision));
+                    $article_url = make_url('publish_article', array('article_name' => $article_name));
+                    if ($revision > 1)
+                    {
+                        $diff_url = make_url('publish_article_diff', array('article_name' => $article_name,
+                                                                           'from_revision' => $revision-1,
+                                                                           'to_revision' => $revision));
                     }
+                    else
+                    {
+                        $diff_url = null;
+                    }
+                    $history_url = make_url('publish_article_history', array('article_name' => $article_name));
+
+                    // Add contribution for consumption in template.
+                    $contributions[] = array('date' => $date,
+                                             'revision' => $revision,
+                                             'article_name' => $article_name,
+                                             'reason' => $reason,
+                                             'author' => $author,
+                                             'author_contributions_url' => $author_contributions_url,
+                                             'revision_url' => $revision_url,
+                                             'article_url' => $article_url,
+                                             'diff_url' => $diff_url,
+                                             'history_url' => $history_url);
                 }
-
-                // Ensure the page size is a valid value (has to be whole number greated than 0).
-                if ($page_size < 1 )
-                {
-                    $page_size = 1;
-                }
-
-                // Calculate number of contributions and how many pages we have.
-                $contributions_size = sizeof($contributions);
-                $total_pages = ceil($contributions_size / $page_size);
-
-                // Ensure we are not out of bounds with page number.
-                if ($page > $total_pages)
-                {
-                    $page = $total_pages;
-                }
-                elseif ($page < 1)
-                {
-                    $page = 1;
-                }
-
-                // Determine starting and ending contribution that fits on this specific page.
-                $page_start_at = ($page - 1) * $page_size;
-                $page_end_at = ($page - 1) * $page_size + $page_size - 1;
-
-                // Make sure we don't go past the last contribution.
-                if ($page_end_at > $contributions_size - 1)
-                {
-                    $page_end_at = $contributions_size - 1;
-                }
-
-                // Calculate pagination URLs.
-                $navigation_urls = array();
-                $page_size_urls = array();
-
-                $base_url = make_url('publish_article', array('article_name' => "Special:{$this->projectnamespace}Contributions")) . '?user=' . $username;
-                $navigation_url_base = $base_url . ($page_size != $default_page_size ? '&page_size=' . $page_size : '');
-
-                $navigation_urls['newest'] = $navigation_url_base . '&page=' . '1';
-                $navigation_urls['oldest'] = $navigation_url_base . '&page=' . $total_pages;
-                $navigation_urls['newer']  = $navigation_url_base . '&page=' . ($page > 1 ? $page - 1 : 1);
-                $navigation_urls['older']  = $navigation_url_base . '&page=' . ($page < $total_pages ? $page + 1 : $total_pages);
-
-                foreach ($available_page_sizes as $available_page_size)
-                {
-                    $page_size_urls[$available_page_size] = $base_url . '&page_size=' . $available_page_size;
-                }
-
-                // Prepare context for template.
-                $this->username = $username;
-                $this->user = $user;
-                $this->contributions = $contributions;
-
-                $this->page = $page;
-                $this->total_pages = $total_pages;
-                $this->page_size = $page_size;
-                $this->page_start_at = $page_start_at;
-                $this->page_end_at = $page_end_at;
-                $this->navigation_urls = $navigation_urls;
-                $this->page_size_urls = $page_size_urls;
-                $this->available_page_sizes = $available_page_sizes;
             }
-            else
+
+            // Ensure the page size is a valid value (has to be whole number greated than 0).
+            if ($page_size < 1 )
             {
-                $this->user = $user;
-                $this->username = $username;
+                $page_size = 1;
             }
+
+            // Calculate number of contributions and how many pages we have.
+            $contributions_size = sizeof($contributions);
+            $total_pages = ceil($contributions_size / $page_size);
+
+            // Ensure we are not out of bounds with page number.
+            if ($page > $total_pages)
+            {
+                $page = $total_pages;
+            }
+            elseif ($page < 1)
+            {
+                $page = 1;
+            }
+
+            // Determine starting and ending contribution that fits on this specific page.
+            $page_start_at = ($page - 1) * $page_size;
+            $page_end_at = ($page - 1) * $page_size + $page_size - 1;
+
+            // Make sure we don't go past the last contribution.
+            if ($page_end_at > $contributions_size - 1)
+            {
+                $page_end_at = $contributions_size - 1;
+            }
+
+            // Calculate pagination URLs.
+            $navigation_urls = array();
+            $page_size_urls = array();
+
+            $navigation_url_base = $base_url . $base_url_user_prefix . ($page_size != $default_page_size ? 'page_size=' . $page_size : '');
+
+            $navigation_urls['newest'] = $navigation_url_base . '&page=' . '1';
+            $navigation_urls['oldest'] = $navigation_url_base . '&page=' . $total_pages;
+            $navigation_urls['newer']  = $navigation_url_base . '&page=' . ($page > 1 ? $page - 1 : 1);
+            $navigation_urls['older']  = $navigation_url_base . '&page=' . ($page < $total_pages ? $page + 1 : $total_pages);
+
+            foreach ($available_page_sizes as $available_page_size)
+            {
+                $page_size_urls[$available_page_size] = $base_url . $base_url_user_prefix . 'page_size='  . $available_page_size;
+            }
+
+            // Prepare context for template.
+            $this->username = $username;
+            $this->user = $user;
+            $this->contributions = $contributions;
+
+            $this->page = $page;
+            $this->total_pages = $total_pages;
+            $this->page_size = $page_size;
+            $this->page_start_at = $page_start_at;
+            $this->page_end_at = $page_end_at;
+            $this->navigation_urls = $navigation_urls;
+            $this->page_size_urls = $page_size_urls;
+            $this->available_page_sizes = $available_page_sizes;
         }
 
         public function componentSpecialContributors()

--- a/modules/publish/Components.php
+++ b/modules/publish/Components.php
@@ -284,5 +284,13 @@
             }
         }
 
+        public function componentSpecialContributors()
+        {
+            $current_project = framework\Context::getCurrentProject();
+
+            $user_ids = ArticleHistory::getTable()->getContributorIDsByProject($current_project);
+
+            $this->contributors = Users::getTable()->getByUserIDs($user_ids);
+            $this->contributions_base_url = make_url('publish_article', array('article_name' => "Special:{$this->projectnamespace}Contributions"));
         }
     }

--- a/modules/publish/Components.php
+++ b/modules/publish/Components.php
@@ -185,9 +185,10 @@
                         $author_contributions_url = "{$base_url}?user={$author->getUsername()}";
                     }
 
-                    // Ignore articles the currently logged-in user can't read.
+                    // Ignore articles the currently logged-in user can't read
+                    // and those that are not part of current project.
                     $article = Article::getByName($article_name);
-                    if (!$article->canRead() || $article->getProject() != $current_project)
+                    if (!$article->hasAccess() || $article->getProject() != $current_project)
                     {
                         continue;
                     }
@@ -225,11 +226,11 @@
             // Ensure the page size is a valid value (has to be whole number greated than 0).
             if ($page_size < 1 )
             {
-                $page_size = 1;
+                $page_size = $default_page_size;
             }
 
             // Calculate number of contributions and how many pages we have.
-            $contributions_size = sizeof($contributions);
+            $contributions_size = count($contributions);
             $total_pages = ceil($contributions_size / $page_size);
 
             // Ensure we are not out of bounds with page number.
@@ -239,7 +240,7 @@
             }
             elseif ($page < 1)
             {
-                $page = 1;
+                $page = $default_page;
             }
 
             // Determine starting and ending contribution that fits on this specific page.

--- a/modules/publish/Components.php
+++ b/modules/publish/Components.php
@@ -4,7 +4,9 @@
 
     use thebuggenie\core\framework,
         thebuggenie\modules\publish\entities\Article,
-        thebuggenie\modules\publish\entities\tables\Articles;
+        thebuggenie\modules\publish\entities\tables\Articles,
+        thebuggenie\modules\publish\entities\tables\ArticleHistory,
+        thebuggenie\core\entities\tables\Users;
 
     class Components extends framework\ActionComponent
     {
@@ -132,4 +134,155 @@
             $this->articles = Articles::getTable()->getAllByLinksToArticleName($this->linked_article_name);
         }
 
+        public function componentSpecialContributions()
+        {
+            $request = framework\Context::getRequest();
+            $current_project = framework\Context::getCurrentProject();
+
+            $available_page_sizes = array(20, 50, 100, 250, 500);
+            $default_page_size = 50;
+            $default_page = 1;
+
+            $username = $request->getParameter('user');
+            $page_size = ceil($request->getParameter('page_size', $default_page_size));
+            $page = floor($request->getParameter('page', $default_page));
+
+            // All contributions made by the user will be stored within this
+            // array.
+            $contributions = array();
+
+            // Try to get the user based on passed ID, or use currently
+            // logged-in user if not provided.
+            if ($username !== null)
+            {
+                $user = Users::getTable()->getByUsername($username);
+            }
+            else
+            {
+                $user = framework\Context::getUser();
+            }
+
+            if ($user !== null)
+            {
+                $history = ArticleHistory::getTable()->getByUser($user);
+
+                if ($history)
+                {
+                    // Contributions by the user will be stored in this specific array.
+                    $contributions = array();
+
+                    while ($row = $history->getNextRow())
+                    {
+                        // Extract basic information.
+                        $date = $row[ArticleHistory::DATE];
+                        $revision = $row[ArticleHistory::REVISION];
+                        $article_name = $row[ArticleHistory::ARTICLE_NAME];
+                        $reason = $row[ArticleHistory::REASON];
+                        $author = $row[ArticleHistory::AUTHOR];
+
+                        // Ignore articles the currently logged-in user can't read.
+                        $article = Article::getByName($article_name);
+                        if (!$article->canRead() || $article->getProject() != $current_project)
+                        {
+                            continue;
+                        }
+
+                        // Calculated properties, primarily URLs.
+                        $revision_url = make_url('publish_article_revision', array('article_name' => $article_name,
+                                                                                   'revision' => $revision));
+                        $article_url = make_url('publish_article', array('article_name' => $article_name));
+                        if ($revision > 1)
+                        {
+                            $diff_url = make_url('publish_article_diff', array('article_name' => $article_name,
+                                                                               'from_revision' => $revision-1,
+                                                                               'to_revision' => $revision));
+                        }
+                        else
+                        {
+                            $diff_url = null;
+                        }
+                        $history_url = make_url('publish_article_history', array('article_name' => $article_name));
+
+                        // Add contribution for consumption in template.
+                        $contributions[] = array('date' => $date,
+                                                 'revision' => $revision,
+                                                 'article_name' => $article_name,
+                                                 'reason' => $reason,
+                                                 'author' => $author,
+                                                 'revision_url' => $revision_url,
+                                                 'article_url' => $article_url,
+                                                 'diff_url' => $diff_url,
+                                                 'history_url' => $history_url);
+                    }
+                }
+
+                // Ensure the page size is a valid value (has to be whole number greated than 0).
+                if ($page_size < 1 )
+                {
+                    $page_size = 1;
+                }
+
+                // Calculate number of contributions and how many pages we have.
+                $contributions_size = sizeof($contributions);
+                $total_pages = ceil($contributions_size / $page_size);
+
+                // Ensure we are not out of bounds with page number.
+                if ($page > $total_pages)
+                {
+                    $page = $total_pages;
+                }
+                elseif ($page < 1)
+                {
+                    $page = 1;
+                }
+
+                // Determine starting and ending contribution that fits on this specific page.
+                $page_start_at = ($page - 1) * $page_size;
+                $page_end_at = ($page - 1) * $page_size + $page_size - 1;
+
+                // Make sure we don't go past the last contribution.
+                if ($page_end_at > $contributions_size - 1)
+                {
+                    $page_end_at = $contributions_size - 1;
+                }
+
+                // Calculate pagination URLs.
+                $navigation_urls = array();
+                $page_size_urls = array();
+
+                $base_url = make_url('publish_article', array('article_name' => "Special:{$this->projectnamespace}Contributions")) . '?user=' . $username;
+                $navigation_url_base = $base_url . ($page_size != $default_page_size ? '&page_size=' . $page_size : '');
+
+                $navigation_urls['newest'] = $navigation_url_base . '&page=' . '1';
+                $navigation_urls['oldest'] = $navigation_url_base . '&page=' . $total_pages;
+                $navigation_urls['newer']  = $navigation_url_base . '&page=' . ($page > 1 ? $page - 1 : 1);
+                $navigation_urls['older']  = $navigation_url_base . '&page=' . ($page < $total_pages ? $page + 1 : $total_pages);
+
+                foreach ($available_page_sizes as $available_page_size)
+                {
+                    $page_size_urls[$available_page_size] = $base_url . '&page_size=' . $available_page_size;
+                }
+
+                // Prepare context for template.
+                $this->username = $username;
+                $this->user = $user;
+                $this->contributions = $contributions;
+
+                $this->page = $page;
+                $this->total_pages = $total_pages;
+                $this->page_size = $page_size;
+                $this->page_start_at = $page_start_at;
+                $this->page_end_at = $page_end_at;
+                $this->navigation_urls = $navigation_urls;
+                $this->page_size_urls = $page_size_urls;
+                $this->available_page_sizes = $available_page_sizes;
+            }
+            else
+            {
+                $this->user = $user;
+                $this->username = $username;
+            }
+        }
+
+        }
     }

--- a/modules/publish/Publish.php
+++ b/modules/publish/Publish.php
@@ -285,7 +285,7 @@
             if (!framework\Context::isCLI())
             {
                 framework\Context::loadLibrary('ui');
-                $options = array();
+                $options = [];
 
                 // Assign CSS class to article if it does not exist.
                 if (Articles::getTable()->getArticleByName($matches[0]) === null)
@@ -293,7 +293,7 @@
                     $options["class"] = "missing_wiki_page";
                 }
 
-                return link_tag(make_url('publish_article', array('article_name' => $matches[0])), $article_name, $options);
+                return link_tag(make_url('publish_article', ['article_name' => $matches[0]]), $article_name, $options);
             }
             else
             {

--- a/modules/publish/Publish.php
+++ b/modules/publish/Publish.php
@@ -267,15 +267,33 @@
             return mb_substr($matches[0], 1);
         }
 
+        /**
+         * Helper function for obtaining article link during parsing of
+         * an Article.
+         *
+         * @param array $matches Result of regular expression matching. First element should be the article name.
+         * @param \thebuggenie\core\helpers\TextParser $parser Parser used for processing the originating article.
+         *
+         * @return string Fully HTML-encoded link (i.e. <a> tag). If article does not exist, tag will be assigned class "missing_wiki_page".
+         */
         public function getArticleLinkTag($matches, $parser)
         {
             $article_link = $matches[0];
             $parser->addInternalLinkOccurrence($article_link);
             $article_name = $this->getSpacedName($matches[0]);
+
             if (!framework\Context::isCLI())
             {
                 framework\Context::loadLibrary('ui');
-                return link_tag(make_url('publish_article', array('article_name' => $matches[0])), $article_name);
+                $options = array();
+
+                // Assign CSS class to article if it does not exist.
+                if (Articles::getTable()->getArticleByName($matches[0]) === null)
+                {
+                    $options["class"] = "missing_wiki_page";
+                }
+
+                return link_tag(make_url('publish_article', array('article_name' => $matches[0])), $article_name, $options);
             }
             else
             {

--- a/modules/publish/configuration/routes.yml
+++ b/modules/publish/configuration/routes.yml
@@ -108,6 +108,8 @@ publish_special_whatlinkshere:
       article_name: Special:WhatLinksHere
     csrf_enabled: false
 
+# This is a "catch-all" route. If you are adding additional routes for
+# Special pages etc, make sure they come before the publish_article one.
 publish_article:
     route: '/wiki/:article_name/*'
     module: publish

--- a/modules/publish/entities/ArticleRevision.php
+++ b/modules/publish/entities/ArticleRevision.php
@@ -220,7 +220,7 @@
          */
         public static function getAuthorContributionsURL($author=null, $project_namespace="")
         {
-            $base_url = make_url('publish_article', array('article_name' => "Special:{$project_namespace}Contributions"));
+            $base_url = make_url('publish_article', ['article_name' => "Special:{$project_namespace}Contributions"]);
 
             if ($author instanceof User)
             {
@@ -248,8 +248,8 @@
          */
         public function getRevisionURL()
         {
-            return make_url('publish_article_revision', array('article_name' => $this->getArticleName(),
-                                                              'revision' => $this->getRevision()));
+            return make_url('publish_article_revision', ['article_name' => $this->getArticleName(),
+                                                         'revision' => $this->getRevision()]);
         }
 
         /**
@@ -260,7 +260,7 @@
          */
         public function getArticleURL()
         {
-            return make_url('publish_article', array('article_name' => $this->getArticleName()));
+            return make_url('publish_article', ['article_name' => $this->getArticleName()]);
         }
 
         /**
@@ -274,9 +274,9 @@
         {
             if ($this->getRevision() > 1)
             {
-                return make_url('publish_article_diff', array('article_name' => $this->getArticleName(),
-                                                              'from_revision' => $this->getRevision()-1,
-                                                              'to_revision' => $this->getRevision()));
+                return make_url('publish_article_diff', ['article_name' => $this->getArticleName(),
+                                                         'from_revision' => $this->getRevision()-1,
+                                                         'to_revision' => $this->getRevision()]);
             }
             else
             {
@@ -292,6 +292,6 @@
          */
         public function getHistoryURL()
         {
-            return make_url('publish_article_history', array('article_name' => $this->getArticleName()));
+            return make_url('publish_article_history', ['article_name' => $this->getArticleName()]);
         }
     }

--- a/modules/publish/entities/ArticleRevision.php
+++ b/modules/publish/entities/ArticleRevision.php
@@ -1,0 +1,297 @@
+<?php
+
+    namespace thebuggenie\modules\publish\entities;
+
+    use thebuggenie\modules\publish\entities\Article,
+        thebuggenie\core\entities\User;
+    /**
+     * @Table(name="\thebuggenie\modules\publish\entities\tables\ArticleHistory")
+     */
+    class ArticleRevision extends \thebuggenie\core\entities\common\IdentifiableScoped
+    {
+        /**
+         * Name of the article.
+         *
+         * @var string
+         * @Column(type="string", length=255)
+         */
+        protected $_article_name;
+
+        /**
+         * Article associated with the revision.
+         *
+         * @var \thebuggenie\modules\publish\entities\Article
+         */
+        protected $_article = null;
+
+        /**
+         * Article content prior to revision.
+         *
+         * @var string
+         * @Column(type="text")
+         */
+        protected $_old_content;
+
+        /**
+         * Article content after the revision.
+         *
+         * @var string
+         * @Column(type="text")
+         */
+        protected $_new_content;
+
+        /**
+         * Reason specified by the author for revision change.
+         *
+         * @var string
+         * @Column(type="text", length=255)
+         */
+        protected $_reason;
+
+        /**
+         * Revision number.
+         *
+         * @var integer
+         * @Column(type="integer", length=10)
+         */
+        protected $_revision;
+
+        /**
+         * Date when the change to article was made.
+         *
+         * @var integer
+         * @Column(type="integer", length=10)
+         */
+        protected $_date;
+
+        /**
+         * Author associated with the revision.
+         *
+         * @var \thebuggenie\core\entities\User
+         * @Column(type="integer", length=10)
+         * @Relates(class="\thebuggenie\core\entities\User")
+         *
+         */
+        protected $_author;
+
+        /**
+         * Article revision constructor.
+         *
+         * @param \b2db\Row $row
+         */
+        public function _construct(\b2db\Row $row, $foreign_key = null)
+        {
+        }
+
+        /**
+         * Returns article name as stored in the article revision.
+         *
+         * @return string
+         */
+        public function getArticleName()
+        {
+            return $this->_article_name;
+        }
+
+        /**
+         * Returns old content of the article (prior to change).
+         *
+         *
+         * @return string
+         */
+        public function getOldContent()
+        {
+            return $this->_old_content;
+        }
+
+        /**
+         * Returns new content of the article (at the time of change).
+         *
+         *
+         * @return string
+         */
+        public function getNewContent()
+        {
+            return $this->_new_content;
+        }
+
+        /**
+         * Returns reason for change as specified by revision author.
+         *
+         *
+         * @return string
+         */
+        public function getReason()
+        {
+            return $this->_reason;
+        }
+
+
+        /**
+         * Returns revision number.
+         *
+         *
+         * @return int
+         */
+        public function getRevision()
+        {
+            return $this->_revision;
+        }
+
+        /**
+         * Returns date of change.
+         *
+         *
+         * @return int
+         */
+        public function getDate()
+        {
+            return $this->_date;
+        }
+
+        /**
+         * Returns revision author.
+         *
+         * @return \thebuggenie\core\entities\User
+         */
+        public function getAuthor()
+        {
+            return $this->_b2dbLazyload('_author');
+        }
+
+
+        /**
+         * Returns author name with username. This method is essentially a light
+         * wrapper around User::getNameWithUsername() which covers the case
+         * where author ID is 0 (i.e. for initial fixtures).
+         *
+         * @retval string
+         *   "none (fixtures)" if author ID was 0, real name and username
+         *   combined if author exists, or null if author could not be
+         *   retrieved.
+         */
+        public function getAuthorNameWithUsername()
+        {
+            $author = $this->getAuthor();
+
+            if ($author instanceof User)
+            {
+                return $author->getNameWithUsername();
+            }
+            elseif (is_numeric($author) && $author == 0)
+            {
+                return "none (fixtures)";
+            }
+
+            return null;
+        }
+
+        /**
+         * Returns article associated with the revision.
+         *
+         *
+         * @return \thebuggenie\modules\publish\entities\Article
+         */
+        public function getArticle()
+        {
+            // Small caching optimisation for fetching the article.
+            if ($this->_article === null)
+            {
+                $this->_article = Article::getByName($this->getArticleName());
+            }
+
+            return $this->_article;
+        }
+
+
+        /**
+         * Returns URL pointing to author contributions.
+         *
+         * @param \thebuggenie\modules\publish\entities\User $author
+         *   Author for which to generate contributions URL. If set to 0,
+         *   returns contribution URL for install-time system fixtures. If set
+         *   to null, returns contributions URL for all users.
+         * @param string $project_namespace
+         *   Project namespace for which the URL should be generated.
+         *
+         * @retval string
+         *   URL pointing to author contributions. If passed-in $author is
+         *   invalid (not a User instance, not 0, and not null), returns null.
+         */
+        public static function getAuthorContributionsURL($author=null, $project_namespace="")
+        {
+            $base_url = make_url('publish_article', array('article_name' => "Special:{$project_namespace}Contributions"));
+
+            if ($author instanceof User)
+            {
+                return "{$base_url}?user={$author->getUsername()}";
+            }
+            elseif (is_numeric($author) && $author == 0)
+            {
+                return "{$base_url}?user=";
+            }
+            elseif ($author === null)
+            {
+                return "{$base_url}";
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /**
+         * Returns URL for viewing this specific revision.
+         *
+         *
+         * @return string
+         */
+        public function getRevisionURL()
+        {
+            return make_url('publish_article_revision', array('article_name' => $this->getArticleName(),
+                                                              'revision' => $this->getRevision()));
+        }
+
+        /**
+         * Returns URL for viewing the article.
+         *
+         *
+         * @return string
+         */
+        public function getArticleURL()
+        {
+            return make_url('publish_article', array('article_name' => $this->getArticleName()));
+        }
+
+        /**
+         * Returns URL for viewing revision differences. If this is the first
+         * revision, returns null.
+         *
+         *
+         * @return string
+         */
+        public function getDiffURL()
+        {
+            if ($this->getRevision() > 1)
+            {
+                return make_url('publish_article_diff', array('article_name' => $this->getArticleName(),
+                                                              'from_revision' => $this->getRevision()-1,
+                                                              'to_revision' => $this->getRevision()));
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /**
+         * Returns history URL for article associated with the revision.
+         *
+         *
+         * @return string
+         */
+        public function getHistoryURL()
+        {
+            return make_url('publish_article_history', array('article_name' => $this->getArticleName()));
+        }
+    }

--- a/modules/publish/entities/tables/ArticleHistory.php
+++ b/modules/publish/entities/tables/ArticleHistory.php
@@ -5,11 +5,13 @@
     use thebuggenie\core\framework,
         thebuggenie\core\entities\tables\ScopedTable,
         thebuggenie\core\entities\tables\Projects,
+        thebuggenie\core\entities\tables\Users,
         b2db\Core,
         b2db\Criteria;
 
     /**
      * @Table(name="articlehistory")
+     * @Entity(class="\thebuggenie\modules\publish\entities\ArticleRevision")
      */
     class ArticleHistory extends ScopedTable
     {
@@ -35,7 +37,7 @@
             parent::_addVarchar(self::REASON, 255);
             parent::_addInteger(self::DATE, 10);
             parent::_addInteger(self::REVISION, 10);
-            parent::_addForeignKeyColumn(self::AUTHOR, \thebuggenie\core\entities\tables\Users::getTable(), \thebuggenie\core\entities\tables\Users::ID);
+            parent::_addForeignKeyColumn(self::AUTHOR, Users::getTable(), Users::ID);
         }
 
         protected function _getNextRevisionNumberForArticle($article_name)
@@ -166,29 +168,109 @@
         }
 
         /**
+         * Returns all article revisions. Entries are sorted based on date, with
+         * newest entry at beginning.
+         *
+         * @retval \thebuggenie\modules\publish\entities\ArticleRevision[]
+         *   Array with all article revisions.
+         */
+        public function getAll()
+        {
+            $crit = $this->getCriteria();
+            $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
+            $crit->addOrderBy(self::DATE, 'desc');
+
+            return $this->select($crit);
+        }
+
+        /**
          * Returns all article history entries based on passed-in user. Entries
          * are sorted based on date, with newest entry at beginning.
          *
          * @param \thebuggenie\core\entities\User $user
-         *   User for which to fetch article history. If null, entire history
-         *   will be retrieved.
+         *   User for which to fetch article history.
          *
-         * @retval \b2db\Resultset
-         *   Result set with requested rows.
+         * @retval \thebuggenie\modules\publish\entities\ArticleRevision[]
+         *   Array with all article revisions produced by specified user.
          */
         public function getByUser($user)
         {
             $crit = $this->getCriteria();
-            if ($user !== null)
-            {
-                $crit->addWhere(self::AUTHOR, $user->getID());
-            }
+            $crit->addWhere(self::AUTHOR, $user->getID());
             $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
             $crit->addOrderBy(self::DATE, 'desc');
 
-            $res = $this->doSelect($crit);
+            return $this->select($crit);
+        }
 
-            return $res;
+        /**
+         * Retrieves all contributions based on author username, and based on
+         * current user's article permissions.
+         *
+         * @param string $author_username
+         *   Author username for which to fetch all contributions. If set to ""
+         *   (empty string), fetches all contributions created via fixtures
+         *   during installation. If set to null, fetches contributions for all
+         *   authors.
+         *
+         * @retval \thebuggenie\modules\publish\entities\ArticleRevision[]
+         *   All contributions by the requested author, or empty array if user
+         *   has no permissions to such contributions or specified author is
+         *   invalid/does not exist.
+         */
+        public function getByAuthorUsernameAndCurrentUserAccess($author_username)
+        {
+            $crit = $this->getCriteria();
+            $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
+
+            if ($author_username === "")
+            {
+                $crit->addWhere(self::AUTHOR, 0);
+            }
+            elseif ($author_username !== null)
+            {
+                $author = Users::getTable()->getByUsername($author_username);
+
+                if ($author === null)
+                {
+                    return [];
+                }
+
+                $crit->addWhere(self::AUTHOR, $author->getID());
+            }
+
+            $crit->addOrderBy(self::DATE, 'desc');
+
+            $history = $this->select($crit);
+
+            $result = [];
+
+            foreach ($history as $revision)
+            {
+                if ($revision->getArticle()->hasAccess())
+                {
+                    $result[] = $revision;
+                }
+            }
+
+            return $result;
+        }
+
+        /**
+         * Returns all article history entries coming from fixtures (author ID
+         * 0).
+         *
+         * @retval \thebuggenie\modules\publish\entities\ArticleRevision[]
+         *   Array with all article revisions produced by specified user.
+         */
+        public function getFromFixtures()
+        {
+            $crit = $this->getCriteria();
+            $crit->addWhere(self::AUTHOR, 0);
+            $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
+            $crit->addOrderBy(self::DATE, 'desc');
+
+            return $this->select($crit);
         }
 
         /**

--- a/modules/publish/entities/tables/ArticleHistory.php
+++ b/modules/publish/entities/tables/ArticleHistory.php
@@ -288,7 +288,7 @@
         public function getContributorIDsByProject($project)
         {
             // All user IDs will get stored here.
-            $result = array();
+            $result = [];
 
             $crit = $this->getCriteria();
             $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());

--- a/modules/publish/entities/tables/ArticleHistory.php
+++ b/modules/publish/entities/tables/ArticleHistory.php
@@ -164,4 +164,24 @@
             $res = $this->doDelete($crit);
         }
 
+        /**
+         * Returns all article history entries tied-in to a specific
+         * user. Entries are sorted based on date, with newest entry at
+         * beginning.
+         *
+         * @param \thebuggenie\core\entities\User $user User for which to fetch article history.
+         *
+         * @return \b2db\Resultset Result set with requested rows.
+         */
+        public function getByUser($user)
+        {
+            $crit = $this->getCriteria();
+            $crit->addWhere(self::AUTHOR, $user->getID());
+            $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
+            $crit->addOrderBy(self::DATE, 'desc');
+
+            $res = $this->doSelect($crit);
+
+            return $res;
+        }
     }

--- a/modules/publish/entities/tables/ArticleHistory.php
+++ b/modules/publish/entities/tables/ArticleHistory.php
@@ -166,18 +166,23 @@
         }
 
         /**
-         * Returns all article history entries tied-in to a specific
-         * user. Entries are sorted based on date, with newest entry at
-         * beginning.
+         * Returns all article history entries based on passed-in user. Entries
+         * are sorted based on date, with newest entry at beginning.
          *
-         * @param \thebuggenie\core\entities\User $user User for which to fetch article history.
+         * @param \thebuggenie\core\entities\User $user
+         *   User for which to fetch article history. If null, entire history
+         *   will be retrieved.
          *
-         * @return \b2db\Resultset Result set with requested rows.
+         * @retval \b2db\Resultset
+         *   Result set with requested rows.
          */
         public function getByUser($user)
         {
             $crit = $this->getCriteria();
-            $crit->addWhere(self::AUTHOR, $user->getID());
+            if ($user !== null)
+            {
+                $crit->addWhere(self::AUTHOR, $user->getID());
+            }
             $crit->addWhere(self::SCOPE, framework\Context::getScope()->getID());
             $crit->addOrderBy(self::DATE, 'desc');
 

--- a/modules/publish/public/css/publish.css
+++ b/modules/publish/public/css/publish.css
@@ -463,3 +463,25 @@ INS { display: inline; background-color: #8D8; text-decoration: none; } DEL { di
     word-wrap: break-word;
     -ms-word-break: break-all;
 }
+
+/* BEGIN: modules/publish/ contributions styling */
+.full_width_table.outter {
+    overflow-x: auto;
+}
+
+.full_width_table.inner {
+    width: 100%;
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+.full_width_table.inner th, .full_width_table.inner td {
+    width: 1%;
+    white-space: nowrap;
+}
+
+.full_width_table.inner th:last-of-type, .full_width_table.inner td:last-of-type {
+    width: auto;
+    white-space: normal;
+}
+/* END: modules/publish/ contributions styling */

--- a/modules/publish/templates/_specialcontributions.inc.php
+++ b/modules/publish/templates/_specialcontributions.inc.php
@@ -4,14 +4,14 @@
     <?php if ($username === null): ?>
     <div class="header" >
         <?= __('Special:Contributions to %namespace namespace',
-               array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
+               ['%namespace' => ($projectnamespace ? $projectnamespace : __('global'))]); ?>
     </div>
     <p>
         <?php if (empty($contributions)): ?>
             <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
         <?php else: ?>
             <?= __('Below is a listing of all contributions made to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
-                   array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+                   ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
         <?php endif ?>
     </p>
 
@@ -19,21 +19,21 @@
     <?php elseif ($username === ""): ?>
     <div class="header" >
         <?= __('Special:Contributions to %namespace namespace created via initial fixtures',
-               array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
+               ['%namespace' => ($projectnamespace ? $projectnamespace : __('global'))]); ?>
     </div>
     <p>
         <?php if (empty($contributions)): ?>
         <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
             <?php else: ?>
         <?= __('Below is a listing of all contributions made via initial fixtures to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
-               array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+               ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
         <?php endif ?>
     </p>
 
 
     <?php elseif ($invalid_user): ?>
     <div class="header">
-        <?= __('Special:Contributions - No such user %username', array('%username' => $username)); ?>
+        <?= __('Special:Contributions - No such user %username', ['%username' => $username]); ?>
     </div>
     <p>
         <?= __('User with specified username does not exist.'); ?>
@@ -43,15 +43,15 @@
     <?php else: ?>
     <div class="header">
         <?= __('Special:Contributions to %namespace namespace by %user_full_name',
-               array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
-                     '%user_full_name' => $user_full_name)); ?>
+               ['%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
+                '%user_full_name' => $user_full_name]); ?>
     </div>
     <p>
         <?php if (empty($contributions)): ?>
             <?= __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
         <?php else: ?>
             <?= __('Below is a listing of all contributions made by this user to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
-                   array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+                   ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
         <?php endif ?>
     </p>
     <?php endif ?>

--- a/modules/publish/templates/_specialcontributions.inc.php
+++ b/modules/publish/templates/_specialcontributions.inc.php
@@ -1,59 +1,56 @@
 <div class="article">
-
-
     <?php if ($username === null): ?>
-    <div class="header" >
-        <?= __('Special:Contributions to %namespace namespace',
-               ['%namespace' => ($projectnamespace ? $projectnamespace : __('global'))]); ?>
-    </div>
-    <p>
-        <?php if (empty($contributions)): ?>
-            <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
-        <?php else: ?>
-            <?= __('Below is a listing of all contributions made to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
-                   ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
-        <?php endif ?>
-    </p>
-
+        <div class="header" >
+            <?= __('Special:Contributions to %namespace namespace',
+                   ['%namespace' => ($projectnamespace ? $projectnamespace : __('global'))]); ?>
+        </div>
+        <p>
+            <?php if (empty($contributions)): ?>
+                <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
+            <?php else: ?>
+                <?= __('Below is a listing of all contributions made to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+                       ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
+            <?php endif ?>
+        </p>
 
     <?php elseif ($username === ""): ?>
-    <div class="header" >
-        <?= __('Special:Contributions to %namespace namespace created via initial fixtures',
-               ['%namespace' => ($projectnamespace ? $projectnamespace : __('global'))]); ?>
-    </div>
-    <p>
-        <?php if (empty($contributions)): ?>
-        <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
+        <div class="header" >
+            <?= __('Special:Contributions to %namespace namespace created via initial fixtures',
+                   ['%namespace' => ($projectnamespace ? $projectnamespace : __('global'))]); ?>
+        </div>
+        <p>
+            <?php if (empty($contributions)): ?>
+                <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
             <?php else: ?>
-        <?= __('Below is a listing of all contributions made via initial fixtures to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
-               ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
-        <?php endif ?>
-    </p>
+                <?= __('Below is a listing of all contributions made via initial fixtures to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+                       ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
+            <?php endif ?>
+        </p>
 
 
     <?php elseif ($invalid_user): ?>
-    <div class="header">
-        <?= __('Special:Contributions - No such user %username', ['%username' => $username]); ?>
-    </div>
-    <p>
-        <?= __('User with specified username does not exist.'); ?>
-    </p>
+        <div class="header">
+            <?= __('Special:Contributions - No such user %username', ['%username' => $username]); ?>
+        </div>
+        <p>
+            <?= __('User with specified username does not exist.'); ?>
+        </p>
 
 
     <?php else: ?>
-    <div class="header">
-        <?= __('Special:Contributions to %namespace namespace by %user_full_name',
-               ['%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
-                '%user_full_name' => $user_full_name]); ?>
-    </div>
-    <p>
-        <?php if (empty($contributions)): ?>
-            <?= __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
-        <?php else: ?>
-            <?= __('Below is a listing of all contributions made by this user to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
-                   ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
-        <?php endif ?>
-    </p>
+        <div class="header">
+            <?= __('Special:Contributions to %namespace namespace by %user_full_name',
+                   ['%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
+                    '%user_full_name' => $user_full_name]); ?>
+        </div>
+        <p>
+            <?php if (empty($contributions)): ?>
+                <?= __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
+            <?php else: ?>
+                <?= __('Below is a listing of all contributions made by this user to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+                       ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
+            <?php endif ?>
+        </p>
     <?php endif ?>
 
     <?php if (!empty($contributions)): ?>
@@ -78,14 +75,15 @@
                                 <?= ($revision->getDiffURL() ? link_tag($revision->getDiffURL(), 'diff') : 'diff'); ?>
                                 |
                                 <?= link_tag($revision->getHistoryURL(), 'hist'); ?>
-                                )</td>
+                                )
+                            </td>
                             <td><?= link_tag($revision->getArticleURL(), $revision->getArticleName()); ?></td>
                             <?php if ($username === null): ?>
                                 <?php if ($revision->getAuthor() !== null): ?>
                                     <td><?= link_tag($revision->getAuthorContributionsURL($revision->getAuthor()), $revision->getAuthorNameWithUsername()); ?></td>
                                 <?php else: ?>
                                     <td><em><?= __('no author'); ?></em></td>
-                                <?php endif?>
+                                <?php endif ?>
                             <?php endif ?>
                             <td><?= $revision->getReason(); ?></td>
                         </tr>
@@ -94,19 +92,7 @@
             </table>
         </div>
         <div>
-            View (
-            <?= ($page == 1 ? __('newest') : link_tag($navigation_urls['newest'], __('newest'))); ?> |
-            <?= ($page == 1 ? __('newer')  : link_tag($navigation_urls['newer'], __('newer'))); ?>   |
-
-            <?= ($page == $total_pages ? __('older')  : link_tag($navigation_urls['older'], __('older'))); ?> |
-            <?= ($page == $total_pages ? __('oldest') : link_tag($navigation_urls['oldest'], __('oldest'))); ?>
-            )
-            Per page (
-            <?= ($page_size == 20 ? '20' : link_tag($page_size_urls[20], '20')); ?> |
-            <?= ($page_size == 50 ? '50' : link_tag($page_size_urls[50], '50')); ?> |
-            <?= ($page_size == 100 ? '100' : link_tag($page_size_urls[100], '100')); ?> |
-            <?= ($page_size == 500 ? '500' : link_tag($page_size_urls[500], '500')); ?>
-            )
+            <?php include_component('main/pagination', ['pagination' => $pagination]); ?>
         </div>
     <?php endif ?>
 </div>

--- a/modules/publish/templates/_specialcontributions.inc.php
+++ b/modules/publish/templates/_specialcontributions.inc.php
@@ -1,47 +1,59 @@
 <div class="article">
-    <?php if ($username === null && empty($contributions)): ?>
-        <div class="header" >
-            <?= __('Special:Contributions to %namespace namespace',
-                          array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
-        </div>
-        <p>
-            <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
-        </p>
-    <?php elseif ($username === null && !empty($contributions)):  ?>
-        <div class="header" >
-            <?= __('Special:Contributions to %namespace namespace',
-                          array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
-        </div>
-        <p>
-            <?= __('Below is a listing of all contributions made to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
-                          array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
-        </p>
-    <?php elseif ($username !== null && $user === null): ?>
-        <div class="header">
-            <?= __('Special:Contributions - No such user %username', array('%username' => $username)); ?>
-        </div>
-        <p>
-            <?= __('User with specified username does not exist.'); ?>
-        </p>
-    <?php elseif ($username !== null && $user !== null && empty($contributions)): ?>
-        <div class="header">
-            <?= __('Special:Contributions to %namespace namespace by %username',
-                          array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
-                                '%username' => $user)); ?>
-        </div>
-        <p>
-            <?= __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
-        </p>
-    <?php elseif ($username !== null && $user !== null): ?>
-        <div class="header"><?= __('Special:Contributions to %namespace namespace by %username',
-                                          array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
-                                                '%username' => $user)); ?>
 
-        </div>
-        <p>
+
+    <?php if ($username === null): ?>
+    <div class="header" >
+        <?= __('Special:Contributions to %namespace namespace',
+               array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
+    </div>
+    <p>
+        <?php if (empty($contributions)): ?>
+            <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
+        <?php else: ?>
+            <?= __('Below is a listing of all contributions made to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+                   array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+        <?php endif ?>
+    </p>
+
+
+    <?php elseif ($username === ""): ?>
+    <div class="header" >
+        <?= __('Special:Contributions to %namespace namespace created via initial fixtures',
+               array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
+    </div>
+    <p>
+        <?php if (empty($contributions)): ?>
+        <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
+            <?php else: ?>
+        <?= __('Below is a listing of all contributions made via initial fixtures to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+               array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+        <?php endif ?>
+    </p>
+
+
+    <?php elseif ($invalid_user): ?>
+    <div class="header">
+        <?= __('Special:Contributions - No such user %username', array('%username' => $username)); ?>
+    </div>
+    <p>
+        <?= __('User with specified username does not exist.'); ?>
+    </p>
+
+
+    <?php else: ?>
+    <div class="header">
+        <?= __('Special:Contributions to %namespace namespace by %user_full_name',
+               array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
+                     '%user_full_name' => $user_full_name)); ?>
+    </div>
+    <p>
+        <?php if (empty($contributions)): ?>
+            <?= __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
+        <?php else: ?>
             <?= __('Below is a listing of all contributions made by this user to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
-                          array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
-        </p>
+                   array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+        <?php endif ?>
+    </p>
     <?php endif ?>
 
     <?php if (!empty($contributions)): ?>
@@ -59,25 +71,25 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <?php for ($i = $page_start_at; $i <= $page_end_at; $i++): ?>
+                    <?php foreach ($contributions as $revision): ?>
                         <tr>
-                            <td><?= link_tag($contributions[$i]['revision_url'], tbg_formatTime($contributions[$i]['date'], 1)); ?></td>
+                            <td><?= link_tag($revision->getRevisionURL(), tbg_formatTime($revision->getDate(), 1)); ?></td>
                             <td>(
-                                <?= ($contributions[$i]['diff_url']) ? link_tag($contributions[$i]['diff_url'], 'diff') : 'diff'; ?>
+                                <?= ($revision->getDiffURL() ? link_tag($revision->getDiffURL(), 'diff') : 'diff'); ?>
                                 |
-                                <?= link_tag($contributions[$i]['history_url'], 'hist'); ?>
+                                <?= link_tag($revision->getHistoryURL(), 'hist'); ?>
                                 )</td>
-                            <td><?= link_tag($contributions[$i]['article_url'], $contributions[$i]['article_name']); ?></td>
+                            <td><?= link_tag($revision->getArticleURL(), $revision->getArticleName()); ?></td>
                             <?php if ($username === null): ?>
-                                <?php if ($contributions[$i]['author'] !== null): ?>
-                                    <td><?= link_tag($contributions[$i]['author_contributions_url'], $contributions[$i]['author']); ?></td>
+                                <?php if ($revision->getAuthor() !== null): ?>
+                                    <td><?= link_tag($revision->getAuthorContributionsURL($revision->getAuthor()), $revision->getAuthorNameWithUsername()); ?></td>
                                 <?php else: ?>
                                     <td><em><?= __('no author'); ?></em></td>
                                 <?php endif?>
                             <?php endif ?>
-                            <td><?= $contributions[$i]['reason']; ?></td>
+                            <td><?= $revision->getReason(); ?></td>
                         </tr>
-                    <?php endfor ?>
+                    <?php endforeach ?>
                 </tbody>
             </table>
         </div>

--- a/modules/publish/templates/_specialcontributions.inc.php
+++ b/modules/publish/templates/_specialcontributions.inc.php
@@ -1,12 +1,29 @@
 <div class="article">
-    <?php if ($user === null): ?>
+    <?php if ($username === null && empty($contributions)): ?>
+        <div class="header" >
+            <?php echo __('Special:Contributions to %namespace namespace',
+                          array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
+        </div>
+        <p>
+            <?php echo __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
+        </p>
+    <?php elseif ($username === null && !empty($contributions)):  ?>
+        <div class="header" >
+            <?php echo __('Special:Contributions to %namespace namespace',
+                          array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
+        </div>
+        <p>
+            <?php echo __('Below is a listing of all contributions made to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+                          array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+        </p>
+    <?php elseif ($username !== null && $user === null): ?>
         <div class="header">
             <?php echo __('Special:Contributions - No such user %username', array('%username' => $username)); ?>
         </div>
         <p>
             <?php echo __('User with specified username does not exist.'); ?>
         </p>
-    <?php elseif (empty($contributions)): ?>
+    <?php elseif ($username !== null && $user !== null && empty($contributions)): ?>
         <div class="header">
             <?php echo __('Special:Contributions to %namespace namespace by %username',
                           array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
@@ -15,7 +32,7 @@
         <p>
             <?php echo __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
         </p>
-    <?php else: ?>
+    <?php elseif ($username !== null && $user !== null): ?>
         <div class="header"><?php echo __('Special:Contributions to %namespace namespace by %username',
                                           array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
                                                 '%username' => $user)); ?>
@@ -25,6 +42,9 @@
             <?php echo __('Below is a listing of all contributions made by this user to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
                           array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
         </p>
+    <?php endif ?>
+
+    <?php if (!empty($contributions)): ?>
         <div class="full_width_table outter">
             <table class="full_width_table inner">
                 <thead>
@@ -32,6 +52,9 @@
                         <th><?php echo __('Date'); ?></th>
                         <th><?php echo __('Details'); ?></th>
                         <th><?php echo __('Article'); ?></th>
+                        <?php if ($username === null): ?>
+                            <th><?php echo __('Author'); ?></th>
+                        <?php endif ?>
                         <th><?php echo __('Reason'); ?></th>
                     </tr>
                 </thead>
@@ -45,6 +68,13 @@
                                 <?php echo link_tag($contributions[$i]['history_url'], 'hist'); ?>
                                 )</td>
                             <td><?php echo link_tag($contributions[$i]['article_url'], $contributions[$i]['article_name']); ?></td>
+                            <?php if ($username === null): ?>
+                                <?php if ($contributions[$i]['author'] !== null): ?>
+                                    <td><?php echo link_tag($contributions[$i]['author_contributions_url'], $contributions[$i]['author']); ?></td>
+                                <?php else: ?>
+                                    <td><em><?php echo __('no author'); ?></em></td>
+                                <?php endif?>
+                            <?php endif ?>
                             <td><?php echo $contributions[$i]['reason']; ?></td>
                         </tr>
                     <?php endfor ?>

--- a/modules/publish/templates/_specialcontributions.inc.php
+++ b/modules/publish/templates/_specialcontributions.inc.php
@@ -1,0 +1,70 @@
+<div class="article">
+    <?php if ($user === null): ?>
+        <div class="header">
+            <?php echo __('Special:Contributions - No such user %username', array('%username' => $username)); ?>
+        </div>
+        <p>
+            <?php echo __('User with specified username does not exist.'); ?>
+        </p>
+    <?php elseif (empty($contributions)): ?>
+        <div class="header">
+            <?php echo __('Special:Contributions to %namespace namespace by %username',
+                          array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
+                                '%username' => $user)); ?>
+        </div>
+        <p>
+            <?php echo __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
+        </p>
+    <?php else: ?>
+        <div class="header"><?php echo __('Special:Contributions to %namespace namespace by %username',
+                                          array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
+                                                '%username' => $user)); ?>
+
+        </div>
+        <p>
+            <?php echo __('Below is a listing of all contributions made by this user to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+                          array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+        </p>
+        <div class="full_width_table outter">
+            <table class="full_width_table inner">
+                <thead>
+                    <tr>
+                        <th><?php echo __('Date'); ?></th>
+                        <th><?php echo __('Details'); ?></th>
+                        <th><?php echo __('Article'); ?></th>
+                        <th><?php echo __('Reason'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php for ($i = $page_start_at; $i <= $page_end_at; $i++): ?>
+                        <tr>
+                            <td><?php echo link_tag($contributions[$i]['revision_url'], tbg_formatTime($contributions[$i]['date'], 1)); ?></td>
+                            <td>(
+                                <?php echo ($contributions[$i]['diff_url']) ? link_tag($contributions[$i]['diff_url'], 'diff') : 'diff'; ?>
+                                |
+                                <?php echo link_tag($contributions[$i]['history_url'], 'hist'); ?>
+                                )</td>
+                            <td><?php echo link_tag($contributions[$i]['article_url'], $contributions[$i]['article_name']); ?></td>
+                            <td><?php echo $contributions[$i]['reason']; ?></td>
+                        </tr>
+                    <?php endfor ?>
+                </tbody>
+            </table>
+        </div>
+        <div>
+            View (
+            <?php echo ($page == 1 ? __('newest') : link_tag($navigation_urls['newest'], __('newest'))); ?> |
+            <?php echo ($page == 1 ? __('newer')  : link_tag($navigation_urls['newer'], __('newer'))); ?>   |
+
+            <?php echo ($page == $total_pages ? __('older')  : link_tag($navigation_urls['older'], __('older'))); ?> |
+            <?php echo ($page == $total_pages ? __('oldest') : link_tag($navigation_urls['oldest'], __('oldest'))); ?>
+            )
+            Per page (
+            <?php echo ($page_size == 20 ? '20' : link_tag($page_size_urls[20], '20')); ?> |
+            <?php echo ($page_size == 50 ? '50' : link_tag($page_size_urls[50], '50')); ?> |
+            <?php echo ($page_size == 100 ? '100' : link_tag($page_size_urls[100], '100')); ?> |
+            <?php echo ($page_size == 500 ? '500' : link_tag($page_size_urls[500], '500')); ?>
+            )
+        </div>
+    <?php endif ?>
+</div>

--- a/modules/publish/templates/_specialcontributions.inc.php
+++ b/modules/publish/templates/_specialcontributions.inc.php
@@ -1,45 +1,45 @@
 <div class="article">
     <?php if ($username === null && empty($contributions)): ?>
         <div class="header" >
-            <?php echo __('Special:Contributions to %namespace namespace',
+            <?= __('Special:Contributions to %namespace namespace',
                           array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
         </div>
         <p>
-            <?php echo __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
+            <?= __('There are no contributions to this namespace or you are not allowed to access any of the articles in the namespace.'); ?>
         </p>
     <?php elseif ($username === null && !empty($contributions)):  ?>
         <div class="header" >
-            <?php echo __('Special:Contributions to %namespace namespace',
+            <?= __('Special:Contributions to %namespace namespace',
                           array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')))); ?>
         </div>
         <p>
-            <?php echo __('Below is a listing of all contributions made to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+            <?= __('Below is a listing of all contributions made to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
                           array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
         </p>
     <?php elseif ($username !== null && $user === null): ?>
         <div class="header">
-            <?php echo __('Special:Contributions - No such user %username', array('%username' => $username)); ?>
+            <?= __('Special:Contributions - No such user %username', array('%username' => $username)); ?>
         </div>
         <p>
-            <?php echo __('User with specified username does not exist.'); ?>
+            <?= __('User with specified username does not exist.'); ?>
         </p>
     <?php elseif ($username !== null && $user !== null && empty($contributions)): ?>
         <div class="header">
-            <?php echo __('Special:Contributions to %namespace namespace by %username',
+            <?= __('Special:Contributions to %namespace namespace by %username',
                           array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
                                 '%username' => $user)); ?>
         </div>
         <p>
-            <?php echo __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
+            <?= __('This user has made no contributions to the wiki or you are not allowed to access any of the articles the user has contributed to.'); ?>
         </p>
     <?php elseif ($username !== null && $user !== null): ?>
-        <div class="header"><?php echo __('Special:Contributions to %namespace namespace by %username',
+        <div class="header"><?= __('Special:Contributions to %namespace namespace by %username',
                                           array('%namespace' => ($projectnamespace ? $projectnamespace : __('global')),
                                                 '%username' => $user)); ?>
 
         </div>
         <p>
-            <?php echo __('Below is a listing of all contributions made by this user to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
+            <?= __('Below is a listing of all contributions made by this user to %namespace namespace. Contributions are listed only for articles you are allowed to access.',
                           array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
         </p>
     <?php endif ?>
@@ -49,33 +49,33 @@
             <table class="full_width_table inner">
                 <thead>
                     <tr>
-                        <th><?php echo __('Date'); ?></th>
-                        <th><?php echo __('Details'); ?></th>
-                        <th><?php echo __('Article'); ?></th>
+                        <th><?= __('Date'); ?></th>
+                        <th><?= __('Details'); ?></th>
+                        <th><?= __('Article'); ?></th>
                         <?php if ($username === null): ?>
-                            <th><?php echo __('Author'); ?></th>
+                            <th><?= __('Author'); ?></th>
                         <?php endif ?>
-                        <th><?php echo __('Reason'); ?></th>
+                        <th><?= __('Reason'); ?></th>
                     </tr>
                 </thead>
                 <tbody>
                     <?php for ($i = $page_start_at; $i <= $page_end_at; $i++): ?>
                         <tr>
-                            <td><?php echo link_tag($contributions[$i]['revision_url'], tbg_formatTime($contributions[$i]['date'], 1)); ?></td>
+                            <td><?= link_tag($contributions[$i]['revision_url'], tbg_formatTime($contributions[$i]['date'], 1)); ?></td>
                             <td>(
-                                <?php echo ($contributions[$i]['diff_url']) ? link_tag($contributions[$i]['diff_url'], 'diff') : 'diff'; ?>
+                                <?= ($contributions[$i]['diff_url']) ? link_tag($contributions[$i]['diff_url'], 'diff') : 'diff'; ?>
                                 |
-                                <?php echo link_tag($contributions[$i]['history_url'], 'hist'); ?>
+                                <?= link_tag($contributions[$i]['history_url'], 'hist'); ?>
                                 )</td>
-                            <td><?php echo link_tag($contributions[$i]['article_url'], $contributions[$i]['article_name']); ?></td>
+                            <td><?= link_tag($contributions[$i]['article_url'], $contributions[$i]['article_name']); ?></td>
                             <?php if ($username === null): ?>
                                 <?php if ($contributions[$i]['author'] !== null): ?>
-                                    <td><?php echo link_tag($contributions[$i]['author_contributions_url'], $contributions[$i]['author']); ?></td>
+                                    <td><?= link_tag($contributions[$i]['author_contributions_url'], $contributions[$i]['author']); ?></td>
                                 <?php else: ?>
-                                    <td><em><?php echo __('no author'); ?></em></td>
+                                    <td><em><?= __('no author'); ?></em></td>
                                 <?php endif?>
                             <?php endif ?>
-                            <td><?php echo $contributions[$i]['reason']; ?></td>
+                            <td><?= $contributions[$i]['reason']; ?></td>
                         </tr>
                     <?php endfor ?>
                 </tbody>
@@ -83,17 +83,17 @@
         </div>
         <div>
             View (
-            <?php echo ($page == 1 ? __('newest') : link_tag($navigation_urls['newest'], __('newest'))); ?> |
-            <?php echo ($page == 1 ? __('newer')  : link_tag($navigation_urls['newer'], __('newer'))); ?>   |
+            <?= ($page == 1 ? __('newest') : link_tag($navigation_urls['newest'], __('newest'))); ?> |
+            <?= ($page == 1 ? __('newer')  : link_tag($navigation_urls['newer'], __('newer'))); ?>   |
 
-            <?php echo ($page == $total_pages ? __('older')  : link_tag($navigation_urls['older'], __('older'))); ?> |
-            <?php echo ($page == $total_pages ? __('oldest') : link_tag($navigation_urls['oldest'], __('oldest'))); ?>
+            <?= ($page == $total_pages ? __('older')  : link_tag($navigation_urls['older'], __('older'))); ?> |
+            <?= ($page == $total_pages ? __('oldest') : link_tag($navigation_urls['oldest'], __('oldest'))); ?>
             )
             Per page (
-            <?php echo ($page_size == 20 ? '20' : link_tag($page_size_urls[20], '20')); ?> |
-            <?php echo ($page_size == 50 ? '50' : link_tag($page_size_urls[50], '50')); ?> |
-            <?php echo ($page_size == 100 ? '100' : link_tag($page_size_urls[100], '100')); ?> |
-            <?php echo ($page_size == 500 ? '500' : link_tag($page_size_urls[500], '500')); ?>
+            <?= ($page_size == 20 ? '20' : link_tag($page_size_urls[20], '20')); ?> |
+            <?= ($page_size == 50 ? '50' : link_tag($page_size_urls[50], '50')); ?> |
+            <?= ($page_size == 100 ? '100' : link_tag($page_size_urls[100], '100')); ?> |
+            <?= ($page_size == 500 ? '500' : link_tag($page_size_urls[500], '500')); ?>
             )
         </div>
     <?php endif ?>

--- a/modules/publish/templates/_specialcontributors.inc.php
+++ b/modules/publish/templates/_specialcontributors.inc.php
@@ -2,12 +2,18 @@
     <div class="header">
         <?php echo __('Special:Contributors for %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
     </div>
-    <p>
-        <?php echo __('Below is a listing of all contributors in %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
-    </p>
-    <ul>
-        <?php foreach ($contributors as $contributor): ?>
-            <li><?php echo link_tag($contributions_base_url . '?user=' . $contributor->getUsername(), $contributor); ?></li>
-        <?php endforeach ?>
-    </ul>
+    <?php if ($contributors): ?>
+        <p>
+            <?php echo __('Below is a listing of all contributors in %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
+        </p>
+        <ul>
+            <?php foreach ($contributors as $contributor): ?>
+                <li><?php echo link_tag($contributions_base_url . '?user=' . $contributor->getUsername(), $contributor); ?></li>
+            <?php endforeach ?>
+        </ul>
+    <?php else: ?>
+        <p>
+            <?php echo __('No contributors have made any changes in the %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
+        </p>
+    <?php endif ?>
 </div>

--- a/modules/publish/templates/_specialcontributors.inc.php
+++ b/modules/publish/templates/_specialcontributors.inc.php
@@ -1,0 +1,13 @@
+<div class="article">
+    <div class="header">
+        <?php echo __('Special:Contributors for %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+    </div>
+    <p>
+        <?php echo __('Below is a listing of all contributors in %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
+    </p>
+    <ul>
+        <?php foreach ($contributors as $contributor): ?>
+            <li><?php echo link_tag($contributions_base_url . '?user=' . $contributor->getUsername(), $contributor); ?></li>
+        <?php endforeach ?>
+    </ul>
+</div>

--- a/modules/publish/templates/_specialcontributors.inc.php
+++ b/modules/publish/templates/_specialcontributors.inc.php
@@ -1,10 +1,10 @@
 <div class="article">
     <div class="header">
-        <?= __('Special:Contributors for %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+        <?= __('Special:Contributors for %namespace namespace', ['%namespace' => ($projectnamespace ? $projectnamespace : 'global')]); ?>
     </div>
     <?php if ($contributors): ?>
         <p>
-            <?= __('Below is a listing of all contributors in %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
+            <?= __('Below is a listing of all contributors in %namespace namespace', ['%namespace' => ($projectnamespace ? $projectnamespace: 'global')]); ?>
         </p>
         <ul>
             <?php foreach ($contributors as $contributor): ?>
@@ -13,7 +13,7 @@
         </ul>
     <?php else: ?>
         <p>
-            <?= __('No contributors have made any changes in the %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
+            <?= __('No contributors have made any changes in the %namespace namespace', ['%namespace' => ($projectnamespace ? $projectnamespace: 'global')]); ?>
         </p>
     <?php endif ?>
 </div>

--- a/modules/publish/templates/_specialcontributors.inc.php
+++ b/modules/publish/templates/_specialcontributors.inc.php
@@ -1,19 +1,19 @@
 <div class="article">
     <div class="header">
-        <?php echo __('Special:Contributors for %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
+        <?= __('Special:Contributors for %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace : 'global'))); ?>
     </div>
     <?php if ($contributors): ?>
         <p>
-            <?php echo __('Below is a listing of all contributors in %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
+            <?= __('Below is a listing of all contributors in %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
         </p>
         <ul>
             <?php foreach ($contributors as $contributor): ?>
-                <li><?php echo link_tag($contributions_base_url . '?user=' . $contributor->getUsername(), $contributor); ?></li>
+                <li><?= link_tag($contributions_base_url . '?user=' . $contributor->getUsername(), $contributor); ?></li>
             <?php endforeach ?>
         </ul>
     <?php else: ?>
         <p>
-            <?php echo __('No contributors have made any changes in the %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
+            <?= __('No contributors have made any changes in the %namespace namespace', array('%namespace' => ($projectnamespace ? $projectnamespace: 'global'))); ?>
         </p>
     <?php endif ?>
 </div>

--- a/modules/publish/templates/_specialspecialpages.inc.php
+++ b/modules/publish/templates/_specialspecialpages.inc.php
@@ -26,6 +26,7 @@
     <h3><?php echo __('Wiki maintenance'); ?></h3>
     <ul class="category_list">
         <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}Contributors")), __('Contributors'), array('title' => "Special:{$projectnamespace}Contributors")); ?></li>
+        <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}Contributions")), __('Contributions'), array('title' => "Special:{$projectnamespace}Contributions")); ?></li>
         <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}DeadEndPages")), __('Dead end pages'), array('title' => "Special:{$projectnamespace}DeadEndPages")); ?></li>
         <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}UncategorizedPages")), __('Uncategorized pages'), array('title' => "Special:{$projectnamespace}UncategorizedPages")); ?></li>
         <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}OrphanedPages")), __('Orphaned pages'), array('title' => "Special:{$projectnamespace}OrphanedPages")); ?></li>

--- a/modules/publish/templates/_specialspecialpages.inc.php
+++ b/modules/publish/templates/_specialspecialpages.inc.php
@@ -25,6 +25,7 @@
     <br style="clear: both;">
     <h3><?php echo __('Wiki maintenance'); ?></h3>
     <ul class="category_list">
+        <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}Contributors")), __('Contributors'), array('title' => "Special:{$projectnamespace}Contributors")); ?></li>
         <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}DeadEndPages")), __('Dead end pages'), array('title' => "Special:{$projectnamespace}DeadEndPages")); ?></li>
         <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}UncategorizedPages")), __('Uncategorized pages'), array('title' => "Special:{$projectnamespace}UncategorizedPages")); ?></li>
         <li><?php echo link_tag(make_url('publish_article', array('article_name' => "Special:{$projectnamespace}OrphanedPages")), __('Orphaned pages'), array('title' => "Special:{$projectnamespace}OrphanedPages")); ?></li>

--- a/themes/firehouse/css/theme.css
+++ b/themes/firehouse/css/theme.css
@@ -14,6 +14,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: bold; padding: 3px 3px 3px 0; margin: 5px 
 table, img, a img { border: 0; }
 
 a { color: #00a400; text-decoration: none; }
+a.missing_wiki_page { color: #a40000; text-decoration: none; }
 a.image:hover { border: 0px; }
 a.issue_closed { text-decoration: line-through; }
 a:hover { border-bottom: 1px dotted #AAA; }

--- a/themes/firehouse/css/theme.css
+++ b/themes/firehouse/css/theme.css
@@ -2981,3 +2981,22 @@ table.sortable tr th.nosort {
 .fullpage_backdrop.tutorial { background-color: rgba(255, 255, 255, 0.8); }
 .fullpage_backdrop.dark { background-color: rgba(0, 0, 0, 0.7); }
 .fullpage_backdrop.tutorial.seethrough { background-color: rgba(0, 0, 0, 0); }
+
+/* generic paginator */
+.paginator {
+    text-align: center;
+    width: auto;
+    margin: 10px auto 10px auto;
+    padding: 3px 5px 3px 5px;
+    font-size: 13px;
+}
+
+.paginator .pages {
+    margin: 0 0 5px 0;
+}
+
+.paginator a {
+    font-weight: normal;
+    padding: 2px 5px 1px 5px !important;
+}
+/* end generic paginator */

--- a/themes/oxygen/css/theme.css
+++ b/themes/oxygen/css/theme.css
@@ -18761,3 +18761,22 @@ form.disabled .address-container + input[type=submit], .address-container ~ .cha
 #config_modules .address-settings p {
     padding: 0 0 15px 0;
 }
+
+/* generic paginator */
+.paginator {
+    text-align: center;
+    width: auto;
+    margin: 10px auto 10px auto;
+    padding: 3px 5px 3px 5px;
+    font-size: 13px;
+}
+
+.paginator .pages {
+    margin: 0 0 5px 0;
+}
+
+.paginator a {
+    font-weight: normal;
+    padding: 2px 5px 1px 5px !important;
+}
+/* end generic paginator */

--- a/themes/oxygen/css/theme.css
+++ b/themes/oxygen/css/theme.css
@@ -60,6 +60,11 @@ a {
     text-decoration: none;
 }
 
+a.missing_wiki_page {
+    color: #a40000;
+    text-decoration: none;
+}
+
 a.image:hover {
     border: 0;
 }

--- a/themes/tanuki/css/theme.css
+++ b/themes/tanuki/css/theme.css
@@ -18972,3 +18972,22 @@ body.mobile_leftmenu_visible #main_container {
     text-align: right;
 }
 .mobile_leftmenu_visible .mobile_menu.left + .mobile_menu_aborter, .mobile_rightmenu_visible .mobile_menu.right + .mobile_menu_aborter { display: block; }
+
+/* generic paginator */
+.paginator {
+    text-align: center;
+    width: auto;
+    margin: 10px auto 10px auto;
+    padding: 3px 5px 3px 5px;
+    font-size: 13px;
+}
+
+.paginator .pages {
+    margin: 0 0 5px 0;
+}
+
+.paginator a {
+    font-weight: normal;
+    padding: 2px 5px 1px 5px !important;
+}
+/* end generic paginator */

--- a/themes/tanuki/css/theme.css
+++ b/themes/tanuki/css/theme.css
@@ -60,6 +60,11 @@ a {
     text-decoration: none;
 }
 
+a.missing_wiki_page {
+    color: #a40000;
+    text-decoration: none;
+}
+
 a.image:hover {
     border: 0;
 }


### PR DESCRIPTION
This pull requests takes care of the following items from issue #610:

2. List of all changes made to project wiki. (help tracking changes and wiki spam)
3. List of all changes made by particular user to project wiki (help tracking changes and wiki spam)
4. wiki links to empty pages should be in different color (not green)

Features implemented:

- Wiki links to empty pages will show-up in red (in oxygen and tanuki themes).
- New special page for listing user contributors:
    - `Special:Contributors`
    - `Special:PROJECT:Contributors`
- New special page for listing user contributions:
    - `Special:Contributions`
    - `Special:PROJECT:Contributions`
    - Narrow down to specific user via `?user=USERNAME`.
    - Specify page and page size via `?page_size=SIZE&page=PAGE`.
    - Generated listings contain a bunch of different links (to diff, article, user contributions, pagination) for each entry.
    - Responsive tabular representation.

Possible issues:

- Could be used for project name fishing if user is allowed to access global wiki. As a side-note, it looks like user that can't read global wiki can still read special pages, probably unrelated to my pull request.
- Could be used for username fishing if user can access `Special:Contributors` page.
- Not 100% about performance of new pages. Don't have a big install on my side, so if you have somewhere to test it on, that would be great to know.
- Contributions page is not AJAX-y. Might be interesting to add JS for it, although I am not sure I can pump in more time into that feature at the moment.