### PR TITLE
Fixed installation of The Bug Genie via CLI

### DIFF
--- a/core/framework/Context.php
+++ b/core/framework/Context.php
@@ -480,9 +480,8 @@ class Context
             // Set the start time
             self::setLoadStart($starttime[1] + $starttime[0]);
 
-            if (!defined('TBG_CLI')) {
-                self::checkInstallMode();
-            }
+            self::checkInstallMode();
+
             self::getCache()->setPrefix(str_replace('.', '_', Settings::getVersion()));
 
             if (!self::isReadySetup())

--- a/core/lib/ui.inc.php
+++ b/core/lib/ui.inc.php
@@ -244,6 +244,8 @@
         return implode(' ', array_values($option_strings));
     }
 
+if (!function_exists('geshi_highlight'))
+{
     /**
      * Easy way to highlight stuff. Behaves just like highlight_string
      *
@@ -274,7 +276,8 @@
             return false;
         }
         return true;
-    }
+    };
+}
 
     /**
      * Get RGB (red, green, blue) values of hex colour.

--- a/core/modules/main/cli/Install.php
+++ b/core/modules/main/cli/Install.php
@@ -392,7 +392,8 @@
                         $this->cliEcho("\n");
 
                         $this->cliEcho("Finishing installation... \n", 'white', 'bold');
-                        $installed_string = \thebuggenie\core\framework\Settings::getMajorVer() . '.' . \thebuggenie\core\framework\Settings::getMinorVer() . ', installed ' . date('d.m.Y H:i');
+                        $installed_string = \thebuggenie\core\framework\Settings::getVersion() . ', installed ' . date('d.m.Y H:i');
+
                         if ((file_exists(THEBUGGENIE_PATH . 'installed') && !is_writable(THEBUGGENIE_PATH . 'installed')) ||
                             (!file_exists(THEBUGGENIE_PATH . 'installed') && !is_writable(THEBUGGENIE_PATH)))
                         {


### PR DESCRIPTION
Fixed installation of The Bug Genie via CLI:

- Make sure to check for installation mode during context set-up irrespective if
  we are running in GUI or CLI.
- Wrap definition of geshi_highlight function with a conditional to avoid
  redeclare error. This error ocurred only within CLI for some reason.
- Fixed creation of installed file when installing via CLI. Installation string
  was different compared to GUI installation.