### PR TITLE
LDAP module refactoring and CLI

### DIFF
--- a/ansible/files/structure.ldif
+++ b/ansible/files/structure.ldif
@@ -83,12 +83,30 @@ cn: Ignored User
 mail: usernoaccess@tbg.local
 
 # Groups.
-dn: cn=tbg,ou=groups,dc=tbg,dc=local
+dn: cn=tbg1,ou=groups,dc=tbg,dc=local
 objectClass: groupOfUniqueNames
 cn: tbg
 uniqueMember: uid=administrator,ou=people,dc=tbg,dc=local
 uniqueMember: uid=user1,ou=people,dc=tbg,dc=local
+
+dn: cn=tbg2,ou=groups,dc=tbg,dc=local
+objectClass: groupOfUniqueNames
+cn: tbg
 uniqueMember: uid=user2,ou=people,dc=tbg,dc=local
 uniqueMember: uid=user3,ou=people,dc=tbg,dc=local
+
+dn: cn=tbg3,ou=groups,dc=tbg,dc=local
+objectClass: groupOfUniqueNames
+cn: tbg
 uniqueMember: uid=user4,ou=people,dc=tbg,dc=local
 uniqueMember: uid=user5,ou=people,dc=tbg,dc=local
+
+dn: cn=groupnoaccess1,ou=groups,dc=tbg,dc=local
+objectClass: groupOfNames
+cn: groupnoaccess1
+member: uid=usernoaccess,ou=people,dc=tbg,dc=local
+
+dn: cn=groupnoaccess2,ou=groups,dc=tbg,dc=local
+objectClass: groupOfNames
+cn: groupnoaccess2
+member: uid=usernoaccess,ou=people,dc=tbg,dc=local

--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -609,34 +609,14 @@
                         {
                             $external = true;
                             framework\Logging::log('Authenticating without credentials with backend: '.framework\Settings::getAuthenticationBackend(), 'auth', framework\Logging::LEVEL_INFO);
-                            try
-                            {
-                                $mod = framework\Context::getModule(framework\Settings::getAuthenticationBackend());
-                                if ($mod->getType() !== Module::MODULE_AUTH)
-                                {
-                                    framework\Logging::log('Auth module is not the right type', 'auth', framework\Logging::LEVEL_FATAL);
-                                }
+                            $mod = framework\Context::getModule(framework\Settings::getAuthenticationBackend());
 
-                                $user = $mod->doAutoLogin();
-
-                                if ($user == false)
-                                {
-                                    // Invalid
-                                    framework\Context::logout();
-                                    throw new \Exception('No such login');
-                                    //framework\Context::getResponse()->headerRedirect(framework\Context::getRouting()->generate('login'));
-                                }
-                                // In case the operation was a success, but no autologin was enabled, set the user to null
-                                // so the rest of the code that deals with guest access can handle it.
-                                else if ($user == true)
-                                {
-                                    $user = null;
-                                }
-                            }
-                            catch (\Exception $e)
+                            if ($mod->getType() !== Module::MODULE_AUTH)
                             {
-                                throw $e;
+                                framework\Logging::log('Auth module is not the right type', 'auth', framework\Logging::LEVEL_FATAL);
                             }
+
+                            $user = $mod->doAutoLogin();
                         }
                         elseif ($username !== null && $password !== null && !$user instanceof User)
                         {

--- a/core/framework/Context.php
+++ b/core/framework/Context.php
@@ -262,6 +262,13 @@ class Context
 
     public static function errorHandler($code, $error, $file, $line)
     {
+        // Do not run the handler for suppressed errors. Normally this should be
+        // only commands where supression is done via the @ operator.
+        if (error_reporting() === 0)
+        {
+            return false;
+        }
+
         if (self::isDebugMode())
             self::generateDebugInfo();
 

--- a/modules/auth_ldap/Auth_ldap.php
+++ b/modules/auth_ldap/Auth_ldap.php
@@ -24,9 +24,8 @@
      */
     class Auth_ldap extends \thebuggenie\core\entities\Module
     {
-
+        // Module information.
         const VERSION = '2.0';
-
         protected $_name = 'auth_ldap';
         protected $_longname = 'LDAP Authentication';
         protected $_description = 'Allows authentication against a LDAP or Active Directory server';
@@ -34,34 +33,79 @@
         protected $_module_config_description = 'Configure server connection settings';
         protected $_has_config_settings = true;
 
+        /**
+         * LDAP connection handler. Handler is used for control user LDAP
+         * operations. Verification of user login credentials is performed via
+         * dedicated connection.
+         *
+         */
+        protected $_connection = null;
+
+
+        /**
+         * Initialises the module. No module-specific steps are taken for this
+         * module.
+         *
+         */
         protected function _initialize()
         {
-
         }
 
+
+        /**
+         * Installs the module. No module-specific steps are taken for this
+         * module.
+         *
+         * @param thebuggenie\core\entities\Scope $scope
+         *   Scope within which the module is installed.
+         */
         protected function _install($scope)
         {
-
         }
 
+
+        /**
+         * Uninstalls the module. No module-specific steps are taken for this
+         * module.
+         */
         protected function _uninstall()
         {
-
         }
 
+
+        /**
+         * Returns module type.
+         *
+         *
+         * @return int
+         */
         public final function getType()
         {
             return parent::MODULE_AUTH;
         }
 
+
+        /**
+         * Registers listeners for events.
+         */
         protected function _addListeners()
         {
             framework\Event::listen('core', 'thebuggenie\core\modules\configuration\controllers\Main\getAuthenticationMethodForAction', array($this, 'listen_configurationAuthenticationMethod'));
         }
 
+
+        /**
+         * Processes configuration settings submitted by user.
+         *
+         * @param thebuggenie\core\framework\Request $request
+         *   Request containing submitted information.
+         */
         public function postConfigSettings(framework\Request $request)
         {
             $settings = array('hostname', 'u_type', 'g_type', 'b_dn', 'groups', 'dn_attr', 'u_attr', 'g_attr', 'e_attr', 'f_attr', 'b_attr', 'g_dn', 'control_user', 'control_pass', 'integrated_auth', 'integrated_auth_header');
+
+            // Process each setting, and ensure defaults are set if values are
+            // not provided for specific options.
             foreach ($settings as $setting)
             {
                 if (($setting == 'u_type' || $setting == 'g_type' || $setting == 'dn_attr') && $request->getParameter($setting) == '')
@@ -93,377 +137,83 @@
             }
         }
 
-        public function connect()
-        {
-            $host = $this->getSetting('hostname');
-            $failed = false;
 
-            $connection = ldap_connect($host);
-            ldap_set_option($connection, LDAP_OPT_PROTOCOL_VERSION, 3);
-            ldap_set_option($connection, LDAP_OPT_REFERRALS, 0);
-
-            if ($connection == false): $failed = true;
-            endif;
-
-            if ($failed)
-            {
-                throw new \Exception(framework\Context::geti18n()->__('Failed to connect to server'));
-            }
-
-            return $connection;
-        }
-
-        public function bind($connection, $lduser = null, $ldpass = null)
-        {
-            $bind = ldap_bind($connection, $lduser, $ldpass);
-
-            if (!$bind)
-            {
-                ldap_unbind($connection);
-                framework\Logging::log('bind failed: ' . ldap_error($connection), 'ldap', framework\Logging::LEVEL_FATAL);
-                throw new \Exception(framework\Context::geti18n()->__('Failed to bind: ') . ldap_error($connection));
-            }
-        }
-
-        public function escape($string)
-        {
-            $chars = array('*', '()', ')', chr(0));
-            foreach ($chars as $char)
-            {
-                $string = str_replace($char, '\\' . $char, $string);
-            }
-
-            return $string;
-        }
-
-        public function doLogin($username, $password, $mode = 1)
-        {
-            $validgroups = $this->getSetting('groups');
-            $base_dn = $this->getSetting('b_dn');
-            $dn_attr = $this->escape($this->getSetting('dn_attr'));
-            $username_attr = $this->escape($this->getSetting('u_attr'));
-            $fullname_attr = $this->escape($this->getSetting('f_attr'));
-            $buddyname_attr = $this->escape($this->getSetting('b_attr'));
-            $email_attr = $this->escape($this->getSetting('e_attr'));
-            $groups_members_attr = $this->escape($this->getSetting('g_attr'));
-
-            $user_class = framework\Context::getModule('auth_ldap')->getSetting('u_type');
-            $group_class = framework\Context::getModule('auth_ldap')->getSetting('g_type');
-
-            $email = null;
-
-            $integrated_auth = $this->getSetting('integrated_auth');
-
-            /*
-             * Do the LDAP check here.
-             *
-             * If a connection error or something, throw an exception and log
-             *
-             * If we can, set $mail and $realname to correct values from LDAP
-             * otherwise don't touch those variables.
-             *
-             * To log do:
-             * framework\Logging::log('error goes here', 'ldap', framework\Logging::LEVEL_FATAL);
-             */
-            try
-            {
-                /*
-                 * First job is to connect to our control user (may be an anonymous bind)
-                 * so we can find the user we want to log in as/validate.
-                 */
-                $connection = $this->connect();
-
-                $control_user = $this->getSetting('control_user');
-                $control_password = $this->getSetting('control_pass');
-
-                $this->bind($connection, $control_user, $control_password);
-
-                // Assume bind successful, otherwise we would have had an exception
-
-                /*
-                 * Search for a user with the username specified. We search in the base_dn, so we can
-                 * find users in multiple parts of the directory, and only return users of a specific
-                 * class (default person).
-                 *
-                 * We want exactly 1 user to be returned. We get the user's full name, email, cn
-                 * and dn.
-                 */
-                $fields = array($fullname_attr, $buddyname_attr, $email_attr, 'cn', $dn_attr);
-                $filter = '(&(objectClass=' . $this->escape($user_class) . ')(' . $username_attr . '=' . $this->escape($username) . '))';
-
-                $results = ldap_search($connection, $base_dn, $filter, $fields);
-
-                if (!$results)
-                {
-                    framework\Logging::log('failed to search for user: ' . ldap_error($connection), 'ldap', framework\Logging::LEVEL_FATAL);
-                    throw new \Exception(framework\Context::geti18n()->__('Search failed: ') . ldap_error($connection));
-                }
-
-                $data = ldap_get_entries($connection, $results);
-
-                // User does not exist
-                if ($data['count'] == 0)
-                {
-                    framework\Logging::log('could not find user ' . $username . ', class ' . $user_class . ', attribute ' . $username_attr, 'ldap', framework\Logging::LEVEL_FATAL);
-                    throw new \Exception(framework\Context::geti18n()->__('User does not exist in the directory'));
-                }
-
-                // If we have more than 1 user, something is seriously messed up...
-                if ($data['count'] > 1)
-                {
-                    framework\Logging::log('too many users for ' . $username . ', class ' . $user_class . ', attribute ' . $username_attr, 'ldap', framework\Logging::LEVEL_FATAL);
-                    throw new \Exception(framework\Context::geti18n()->__('This user was found multiple times in the directory, please contact your administrator'));
-                }
-
-                /*
-                 * If groups are specified, perform group restriction tests
-                 */
-                if ($validgroups != '')
-                {
-                    /*
-                     * We will repeat this for every group, but groups are supplied as a comma-separated list
-                     */
-                    if (strstr($validgroups, ','))
-                    {
-                        $groups = explode(',', $validgroups);
-                    }
-                    else
-                    {
-                        $groups = array();
-                        $groups[] = $validgroups;
-                    }
-
-                    // Assumed we are initially banned
-                    $allowed = false;
-
-                    foreach ($groups as $group)
-                    {
-                        // No need to carry on looking if we have access
-                        if ($allowed == true): continue;
-                        endif;
-
-                        /*
-                         * Find the group we are looking for, we search the entire directory as per users (See that stuff)
-                         * We want to find 1 group, if we don't get 1, silently ignore this group.
-                         */
-                        $fields2 = array($groups_members_attr);
-                        $filter2 = '(&(objectClass=' . $this->escape($group_class) . ')(cn=' . $this->escape($group) . '))';
-
-                        $results2 = ldap_search($connection, $base_dn, $filter2, $fields2);
-
-                        if (!$results2)
-                        {
-                            framework\Logging::log('failed to search for user after binding: ' . ldap_error($connection), 'ldap', framework\Logging::LEVEL_FATAL);
-                            throw new \Exception(framework\Context::geti18n()->__('Search failed ') . ldap_error($connection));
-                        }
-
-                        $data2 = ldap_get_entries($connection, $results2);
-
-                        if ($data2['count'] != 1)
-                        {
-                            continue;
-                        }
-
-                        /*
-                         * Look through the group's member list. If we are found, grant access.
-                         */
-                        foreach ($data2[0][strtolower($groups_members_attr)] as $member)
-                        {
-                            $member = preg_replace('/(?<=,) +(?=[a-zA-Z])/', '', $member);
-                            $user_dn = preg_replace('/(?<=,) +(?=[a-zA-Z])/', '', $data[0][strtolower($dn_attr)][0]);
-
-                            if (!is_numeric($member) && strtolower($member) == strtolower($user_dn))
-                            {
-                                $allowed = true;
-                            }
-                        }
-                    }
-
-                    if ($allowed == false)
-                    {
-                        throw new \Exception(framework\Context::getI18n()->__('You are not a member of a group allowed to log in'));
-                    }
-                }
-
-                /*
-                 * Set user's properties.
-                 * Realname is obtained from directory, if not found we set it to the username
-                 * Email is obtained from directory, if not found we set it to blank
-                 */
-                if (!array_key_exists(strtolower($fullname_attr), $data[0]))
-                {
-                    $realname = $username;
-                }
-                else
-                {
-                    $realname = $data[0][strtolower($fullname_attr)][0];
-                }
-
-                if (!array_key_exists(strtolower($buddyname_attr), $data[0]))
-                {
-                    $buddyname = $username;
-                }
-                else
-                {
-                    $buddyname = $data[0][strtolower($buddyname_attr)][0];
-                }
-
-                if (!array_key_exists(strtolower($email_attr), $data[0]))
-                {
-                    $email = '';
-                }
-                else
-                {
-                    $email = $data[0][strtolower($email_attr)][0];
-                }
-
-                /*
-                 * If we are performing a non integrated authentication login,
-                 * now bind to the user and see if the credentials
-                 * are valid. We bind using the full DN of the user, so no need for DOMAIN\ stuff
-                 * on Windows, and more importantly it fixes other servers.
-                 *
-                 * If the bind fails (exception), we throw a nicer exception and don't continue.
-                 */
-                if ($mode == 1 && !$integrated_auth)
-                {
-                    try
-                    {
-                        if (!is_array($data[0][strtolower($dn_attr)]))
-                        {
-                            $dn = $data[0][strtolower($dn_attr)];
-                        }
-                        else
-                        {
-                            $dn = $data[0][strtolower($dn_attr)][0];
-                        }
-                        $bind = $this->bind($connection, $this->escape($dn), html_entity_decode($password));
-                    }
-                    catch (\Exception $e)
-                    {
-                        throw new \Exception(framework\Context::geti18n()->__('Your password was not accepted by the server'));
-                    }
-                }
-                /*
-                 * Performing a login using the HTTP authentication header REMOTE_USER to identify
-                 * the current user. Password will NOT be checked as the web server is handling
-                 * authentication which we are trusting.
-                 */
-                elseif ($mode == 1)
-                {
-                    if (!isset($_SERVER[$this->getSetting('integrated_auth_header')]) || $_SERVER[$this->getSetting('integrated_auth_header')] != $username)
-                    {
-                        throw new \Exception(framework\Context::geti18n()->__('HTTP authentication internal error.'));
-                    }
-                }
-            }
-            catch (\Exception $e)
-            {
-                ldap_unbind($connection);
-                throw $e;
-            }
-
-            try
-            {
-                /*
-                 * Get the user object. If the user exists, update the user's
-                 * data from the directory.
-                 */
-                $user = \thebuggenie\core\entities\User::getByUsername($username);
-                if ($user instanceof \thebuggenie\core\entities\User)
-                {
-                    $user->setBuddyname($buddyname);
-                    $user->setRealname($realname);
-                    $user->setPassword($user->getJoinedDate() . $username); // update password
-                    $user->setEmail($email); // update email address
-                    $user->save();
-                }
-                else
-                {
-                    /*
-                     * If not, and we are performing an initial login, create the user object
-                     * if we are validating a log in, kick the user out as the session is invalid.
-                     */
-                    if ($mode == 1)
-                    {
-                        // create user
-                        $user = new \thebuggenie\core\entities\User();
-                        $user->setUsername($username);
-                        $user->setRealname('temporary');
-                        $user->setBuddyname($username);
-                        $user->setEmail('temporary');
-                        $user->setEnabled();
-                        $user->setActivated();
-                        $user->setJoined();
-                        $user->setPassword($user->getJoinedDate() . $username);
-                        $user->save();
-                    }
-                    else
-                    {
-                        throw new \Exception('User does not exist in TBG');
-                    }
-                }
-            }
-            catch (\Exception $e)
-            {
-                ldap_unbind($connection);
-                throw $e;
-            }
-
-            ldap_unbind($connection);
-
-            /*
-             * Set cookies and return user row for general operations.
-             */
-            framework\Context::getResponse()->setCookie('tbg3_username', $username);
-            framework\Context::getResponse()->setCookie('tbg3_password', \thebuggenie\core\entities\User::hashPassword($user->getJoinedDate() . $username, $user->getSalt()));
-
-            return \thebuggenie\core\entities\tables\Users::getTable()->getByUsername($username);
-        }
-
-        public function verifyLogin($username)
-        {
-            return $this->doLogin($username, 'a', 2);
-        }
-
-        /*
-         * Actions on logout
+        /**
+         * Log-in the user with provided credentials.
+         *
+         * @param string $username
+         *   Username  to log-in with.
+         *
+         * @param string $password
+         *   Password to log-in with.
+         *
+         *
+         * @retval thebuggenie\core\entities\User | null
+         *   User object associated with the login. If login has failed, returns
+         *   null.
          */
+        public function doLogin($username, $password)
+        {
+            return $this->_loginUser($username, $password, true);
+        }
 
+
+        /**
+         * Verify log-in credentials for previously logged-in user.
+         *
+         * @param string $username
+         *   Username  to log-in with.
+         *
+         * @param string $password
+         *   Password to log-in with.
+         *
+         *
+         * @retval thebuggenie\core\entities\User | null
+         *   User object associated with the login. If login verification has
+         *   failed, returns null.
+         */
+        public function verifyLogin($username, $password)
+        {
+            return $this->_loginUser($username, $password, false);
+        }
+
+
+        /**
+         * Logs out the user. No module-specific steps are taken for this
+         * module.
+         *
+         */
         public function logout()
         {
-
         }
 
-        /*
-         * Actions on login - if there are no credentials supplied try an autologin
-         *
-         * Will activate auto-login process if HTTP integrated authentication is enabled.
 
-         * Return:
-         * true - succeeded operation but no autologin
-         * false - invalid cookies found
-         * Row from \thebuggenie\core\entities\tables\Users - succeeded operation, user found
+        /**
+         * Automatic login, triggered if no credentials were supplied.
          *
+         * LDAP authentication auto-login implementation is used in conjunction
+         * with HTTP integrated authentication.
+         *
+         * @retval \thebuggenie\core\entities\User | null
+         *   If HTTP integrated authentication is enabled, and appropriate
+         *   header is available in the request, runs login and returns user
+         *   entity if login was successful. Otherwise returns null.
          */
-
         public function doAutoLogin()
         {
+            $user = null;
+
             if ($this->getSetting('integrated_auth'))
             {
-                if (isset($_SERVER[$this->getSetting('integrated_auth_header')]))
-                {
-                    return $this->doLogin($_SERVER[$this->getSetting('integrated_auth_header')], 'a', 1);
-                }
-                else
+                if (!isset($_SERVER[$this->getSetting('integrated_auth_header')]))
                 {
                     throw new \Exception(framework\Context::geti18n()->__('HTTP integrated authentication is enabled but the HTTP header has not been provided by the web server.'));
                 }
+
+                $user = $this->_loginUser($_SERVER[$this->getSetting('integrated_auth_header')], "", true);
             }
-            else
-            {
-                return true;
-            }
+
+            return $user;
         }
 
         public function listen_configurationAuthenticationMethod(framework\Event $event)
@@ -473,4 +223,690 @@
             }
         }
 
+
+        /**
+         * Connects to LDAP server and binds as control user using the module
+         * settings. Once a successful connection has been established, it is
+         * cached for future use in property $_connection.
+         *
+         * In case an error occurs while trying to connect and bind, an
+         * exception is thrown with appopriatelly set message.
+         *
+         */
+        protected function _connectAndBindControlUser()
+        {
+            // Only connect and bind if we have not been able to do so before.
+            if ($this->_connection === null)
+            {
+                // Ignore PHP errors from this function (all PHP ldap_*
+                // functions misuse PHP error handling). This function call does
+                // not open an actual connection, it only verifies the URL
+                // syntax.
+                $connection = @ldap_connect($this->getSetting('hostname'));
+
+                if ($connection === false)
+                {
+                    throw new \Exception(framework\Context::geti18n()->__('LDAP connection URL has invalid syntax.'));
+                }
+                else
+                {
+                    // Default LDAP protocol version used is 2, ensure we are
+                    // using version 3 instead.
+                    ldap_set_option($connection, LDAP_OPT_PROTOCOL_VERSION, 3);
+                    ldap_set_option($connection, LDAP_OPT_REFERRALS, 0);
+
+                    // Ignore PHP errors from this function (all PHP ldap_*
+                    // functions misuse PHP error handling).
+                    $bind_result = @ldap_bind($connection, $this->getSetting('control_user'), $this->getSetting('control_pass'));
+
+                    if ($bind_result === false)
+                    {
+                        throw new \Exception(framework\Context::geti18n()->__('Failed to bind control user: ') . ldap_error($connection));
+                    }
+
+                    // At this point we should have a fully-functioning
+                    // connection. Store the value.
+                    $this->_connection = $connection;
+                }
+            }
+        }
+
+
+        /**
+         * Returns LDAP connection handle. Initialises the handle (connects and
+         * binds) if handle is not initialised.
+         *
+         *
+         * @return LDAP connection handle.
+         */
+        protected function _getConnection()
+        {
+            if ($this->_connection === null)
+            {
+                $this->_connectAndBindControlUser();
+            }
+
+            return $this->_connection;
+        }
+
+
+        /**
+         * Runs a search on an LDAP server using the provided filter and
+         * optional set of attributes to retrieve.
+         *
+         * Base DN for performing the search is taken from the module
+         * configuration.
+         *
+         * @param string $filter
+         *   LDAP filter to use for limiting the results. It is highly
+         *   recommended to prepare filter using the Auth_ldap::_prepareFilter()
+         *   method to avoid syntax errors due to restricted characters
+         *   appearing within the values used in filter matching.
+         *
+         * @param string[] $attributes
+         *   List of attributes to retrieve from the LDAP server for every
+         *   matching entry. Set to null or empty array to retrieve all
+         *   attributes
+         *
+         * @retval array[]
+         *   List of matching entries. Format is the same as returned by
+         *   ldap_get_entries function.
+         */
+        protected function _search($filter, $attributes=null)
+        {
+            // Get the LDAP connection handle.
+            $connection = $this->_getConnection();
+
+            // ldap_search accepts only empty array, null is there for user
+            // convenience.
+            if ($attributes === null)
+            {
+                $attributes = [];
+            }
+
+            // Ignore PHP errors for ldap_search, we'll handle it by checking
+            // return value and grabbing error via ldap_error function. PHP LDAP
+            // functions misuse PHP error handling.
+            $search = @ldap_search($connection, $this->getSetting('b_dn'), $filter, $attributes);
+
+            if ($search === false)
+            {
+                throw new \Exception(framework\Context::geti18n()->__('LDAP search failed. Filter: %filter; Error: %error', ['%filter' => $filter,
+                                                                                                                             '%error' => ldap_error($connection)]));
+            }
+
+            // Ignore PHP errors for ldap_get_entries, we'll handle it by
+            // checking return value and grabbing error via ldap_error
+            // function. PHP LDAP functions misuse PHP error handling.
+            $entries = @ldap_get_entries($connection, $search);
+
+            if ($entries === false || $entries === null)
+            {
+                throw new \Exception('Failed to get entries for performed LDAP search: ' . ldap_error($connection));
+            }
+
+            return $entries;
+        }
+
+
+        /**
+         * Helper function for preparing filter for use with LDAP search. Takes
+         * care of properly escaping values used in searches.
+         *
+         * Example use:
+         *
+         * _prepareFilter('(objectClass=%myclass)', ['%myclass' => 'inetOrgPerson'])");
+         *
+         * @param string $filter
+         *   LDAP filter template to use.
+         *
+         * @param string[] $replacements
+         *   Replacements to use in the filter template. Keys should be strings
+         *   within filter that should be replaced. There is no specific format
+         *   for keys that must be used, it is up to the caller to decide what
+         *   to use as syntax for keys.
+         *
+         *
+         * @retval string
+         *   Prepared filter.
+         */
+        protected function _prepareFilter($filter, $replacements)
+        {
+            if (!empty($replacements))
+            {
+                $filter = str_replace(array_keys($replacements),
+                                      array_map(function($value) { return ldap_escape($value, null, LDAP_ESCAPE_FILTER); },
+                                                array_values($replacements)), $filter);
+            }
+
+            return $filter;
+        }
+
+
+        /**
+         * Performs basic connectivity and settings test. The following is
+         * tested:
+         *
+         * - Ability to connect and bind as control user (TBG user for
+         *   performing searches).
+         * - Group configuration.
+         * - Integrated authentication (if enabled).
+         *
+         * @retval array|true
+         *   Result of test. In case of success, returns true. If an error
+         *   occurred, an array is returned with the following keys:
+         *
+         *   summary
+         *     Short summary of error.
+         *
+         *   details
+         *     Detailed error message, usually includes an LDAP error message as
+         *     well.
+         */
+        public function testConnection()
+        {
+            // We'll catch all exceptions and return them in a nice format for
+            // consumption.
+            try
+            {
+                // Verify connectivity.
+                $this->_connectAndBindControlUser();
+
+                // Verify that configured groups used for allowing access exist.
+                $allowed_groups = $this->getSetting('groups');
+
+                if ($allowed_groups != "")
+                {
+                    $member_attribute = $this->getSetting('g_attr');
+                    $group_class = $this->getSetting('g_type');
+
+                    $invalid_groups = [];
+                    $attributes = [$member_attribute];
+
+                    foreach (explode(',', $allowed_groups) as $group)
+                    {
+                        $filter = $this->_prepareFilter("(&(cn=%group)(objectClass=%objectclass))", ['%group' => $group,
+                                                                                                     '%objectclass' => $group_class]);
+                        $entries = $this->_search($filter, $attributes);
+
+                        if ($entries['count'] != 1)
+                        {
+                            $invalid_groups[] = $group;
+                        }
+                    }
+
+                    if (count($invalid_groups) != 0)
+                    {
+                        throw new \Exception(framework\Context::geti18n()->__('Failed to validate groups (groups do not exist or multiple entries were found): %groups',
+                                                                              ['%groups' => implode(', ', $invalid_groups)]));
+                    }
+                }
+
+                // Verify that header is present if HTTP integrated
+                // authentication option is enabled.
+                if ($this->getSetting('integrated_auth'))
+                {
+                    $header_field = $this->getSetting('integrated_auth_header');
+
+                    if (!isset($_SERVER[$header_field]))
+                    {
+                        throw new \Exception(framework\Context::getI18n()->__('HTTP integrated authentication is enabled but the %headerfield header is not being provided to The Bug Genie. Please check your web server configuration.', ['%headerfield' => $header_field]));
+                    }
+                }
+            }
+            catch (\Exception $e)
+            {
+                return ['summary' => framework\Context::getI18n()->__('LDAP connection test failed'),
+                        'details' => $e->getMessage()];
+            }
+
+            return true;
+        }
+
+
+        /**
+         * Retrieves a list of LDAP users authorised to access TBG based on
+         * group membership.
+         *
+         *
+         * @retval string[] | null
+         *   List of LDAP user DNs, lower-cased, which are allowed to access
+         *   TBG. If group restrictions have not been configured in TBG, returns
+         *   null.
+         */
+        protected function _getAllowedLDAPUsersByGroupMembership()
+        {
+            // Get list of groups from configuration.
+            $allowed_groups = framework\Context::getModule('auth_ldap')->getSetting('groups');
+
+            // Indicates no checks based on groups.
+            if ($allowed_groups == "")
+            {
+                return null;
+            }
+
+            // List of all user DNs that are allowed access.
+            $result = [];
+
+            $dn_attr = $this->getSetting('dn_attr');
+
+            // Extract configuration for access control based on group membership.
+            $group_class = strtolower(framework\Context::getModule('auth_ldap')->getSetting('g_type'));
+            $groups_members_attr = strtolower(framework\Context::getModule('auth_ldap')->getSetting('g_attr'));
+
+            // Filter for matching all the different groups. Result should be
+            // along the lines of '(cn=group1)(cn=group2)'.
+            $group_cn_filter = "";
+            foreach (explode(',', $allowed_groups) as $allowed_group)
+            {
+                $group_cn_filter = $group_cn_filter . $this->_prepareFilter('(cn=%cn)', ['%cn' => $allowed_group]);
+            }
+
+            // Grab all the non-empty groups we are interested in.
+            $filter = $this->_prepareFilter("(&(|{$group_cn_filter})(objectClass=%group_class)(%groups_members_attr=*))", ['%group_class' => $group_class,
+                                                                                                                           '%groups_members_attr' => $groups_members_attr]);
+            $attributes = [$groups_members_attr, 'cn', $dn_attr];
+            $groups = $this->_search($filter, $attributes);
+
+            unset($groups['count']);
+
+            // Go through all members, adding them to array.
+            foreach ($groups as $group)
+            {
+                unset($group[$groups_members_attr]['count']);
+                foreach ($group[$groups_members_attr] as $member)
+                {
+                    $result[] = strtolower($member);
+                }
+            }
+
+            return array_unique($result);
+        }
+
+
+        /**
+         * Retrieves user information from an LDAP directory.
+         *
+         * @param string $username
+         *   Limit the search to username with specified username. If set to
+         *   null, retrieve all users.
+         *
+         * @retval array
+         *   An array with information about all users. Every user is
+         *   represented by one item, which is an array on its own with the
+         *   following keys available:
+         *
+         *   - ldap_username (LDAP user DN)
+         *   - username
+         *   - realname
+         *   - buddyname
+         *   - email
+         */
+        protected function _getLDAPUserInformation($username=null)
+        {
+            // Extract general LDAP configuration.
+            $dn_attr = framework\Context::getModule('auth_ldap')->getSetting('dn_attr');
+
+            // Extract configuration for user attribute mapping.
+            $user_class = framework\Context::getModule('auth_ldap')->getSetting('u_type');
+            $username_attr = framework\Context::getModule('auth_ldap')->getSetting('u_attr');
+            $fullname_attr = framework\Context::getModule('auth_ldap')->getSetting('f_attr');
+            $buddyname_attr = framework\Context::getModule('auth_ldap')->getSetting('b_attr');
+            $email_attr = framework\Context::getModule('auth_ldap')->getSetting('e_attr');
+
+            // Grab allowed LDAP users by group membership.
+            $allowed_ldap_users = $this->_getAllowedLDAPUsersByGroupMembership();
+
+            // Retrieve all users in the LDAP directory based on object class
+            // and username (if provided). CN is used as fallback for some user
+            // settings later on.
+            $attributes = array($fullname_attr, $buddyname_attr, $username_attr, $email_attr, $dn_attr, 'cn');
+            if ($username !== null)
+            {
+                $filter = $this->_prepareFilter('(&(objectClass=%user_class)(%username_attr=%username))', ['%user_class' => $user_class,
+                                                                                                           '%username_attr' => $username_attr,
+                                                                                                           '%username' => $username]);
+            }
+            else
+            {
+                $filter = $this->_prepareFilter('(&(objectClass=%user_class)(%username_attr=*))', ['%user_class' => $user_class,
+                                                                                                   '%username_attr' => $username_attr]);
+            }
+            $ldap_users = $this->_search($filter, $attributes);
+
+            // We'll store information in this array.
+            $users = [];
+
+            // Iterate LDAP users.
+            unset($ldap_users['count']);
+            foreach ($ldap_users as $ldap_user)
+            {
+                if ($allowed_ldap_users === null || in_array(strtolower($ldap_user[$dn_attr][0]), $allowed_ldap_users))
+                {
+                    $user = [];
+
+                    // Grab the full name, falling back to cn if available.
+                    if (array_key_exists(strtolower($fullname_attr), $ldap_user))
+                    {
+                        $user['realname'] = $ldap_user[strtolower($fullname_attr)][0];
+                    }
+                    elseif (array_key_exists(strtolower('cn'), $ldap_user))
+                    {
+                        $user['realname'] = $ldap_user['cn'][0];
+                    }
+                    else
+                    {
+                        $user['realname'] = "";
+                    }
+
+                    // Grab the buddy name, falling back to cn if available.
+                    if (array_key_exists(strtolower($buddyname_attr), $ldap_user))
+                    {
+                        $user['buddyname'] = $ldap_user[strtolower($buddyname_attr)][0];
+
+                    }
+                    elseif (array_key_exists(strtolower('cn'), $ldap_user))
+                    {
+                        $user['buddyname'] = $ldap_user['cn'][0];
+                    }
+                    else
+                    {
+                        $user['buddyname'] = "";
+                    }
+
+                    // Grab e-mail if present.
+                    if (array_key_exists(strtolower($email_attr), $ldap_user))
+                    {
+                        $user['email'] = $ldap_user[strtolower($email_attr)][0];
+                    }
+                    else
+                    {
+                        $user['email'] = '';
+                    }
+
+                    // Grab username.
+                    $user['username'] = $ldap_user[strtolower($username_attr)][0];
+
+                    // Grab DN.
+                    $user['ldap_username'] = $ldap_user[$dn_attr][0];
+
+                    $users[] = $user;
+                }
+            }
+
+            return $users;
+        }
+
+
+        /**
+         * Imports and updates all valid users from LDAP directory. This method
+         * will not remove existing users if they cannot be located in the LDAP
+         * directory.
+         *
+         *
+         * @retval array
+         *   Array with statistics information. The following keys are
+         *   available:
+         *
+         *   imported
+         *     Number of imported (new) users.
+         *
+         *   updated
+         *     Number of updated users.
+         *
+         *   total
+         *     Total number of valid LDAP users found.
+         */
+        public function importAndUpdateUsers()
+        {
+            // Fetch user information from LDAP server.
+            $ldap_users = $this->_getLDAPUserInformation();
+
+            // Counters for statistics.
+            $import_count = 0;
+            $update_count = 0;
+            $total_count = count($ldap_users);
+
+            /*
+             * For every user that was found, either create a new user object, or update
+             * the existing one. This will update the created and updated counts as appropriate.
+             */
+            foreach ($ldap_users as $ldap_user)
+            {
+                list($user, $created) = $this->_createOrUpdateUser($ldap_user);
+
+                if ($created === true)
+                {
+                    $import_count++;
+                }
+                else
+                {
+                    $update_count++;
+                }
+            }
+
+            return ['imported' => $import_count,
+                    'updated' => $update_count,
+                    'total' => $total_count];
+        }
+
+
+        /**
+         * Removes all users which are not present in the LDAP directory.
+         *
+         *
+         * @retval array
+         *   Array with statistics information. The following keys are
+         *   available:
+         *
+         *   deleted
+         *     Number of imported (new) users.
+         *
+         *   total_ldap
+         *     Total number of valid LDAP users found.
+         *
+         *   total_tbg
+         *     Total number of TBG users found.
+         */
+        public function pruneUsers()
+        {
+            // Fetch user information from LDAP server.
+            $ldap_users = $this->_getLDAPUserInformation();
+
+            // Fetch TBG users.
+            $tbg_users = \thebuggenie\core\entities\User::getAll();
+
+            // Counters for statistics
+            $delete_count = 0;
+            $total_ldap_count = count($ldap_users);
+            $total_tbg_count = count($tbg_users);
+
+            // Extract all TBG usernames for LDAP users.
+            $usernames_to_keep = array_map(function($user) { return $user['username']; }, $ldap_users);
+
+            $default = framework\Settings::getDefaultUserID();
+
+            foreach ($tbg_users as $tbg_user)
+            {
+                if ($tbg_user->getID() != $default && !in_array($tbg_user->getUsername(), $usernames_to_keep))
+                {
+                    $delete_count++;
+                    $tbg_user->delete();
+                }
+            }
+
+            return ['deleted' => $delete_count,
+                    'total_ldap' => $total_ldap_count,
+                    'total_tbg' => $total_tbg_count];
+        }
+
+
+        /**
+         * Verifies username and password login against LDAP server.
+         *
+         * @param string $username
+         *   Username to log-in with. Keep in mind this is DN in case of LDAP.
+         *
+         * @param string $password
+         *   Password to log-in with.
+         *
+         *
+         * @retval bool
+         *   Returns true, if username + password combination is valid, false
+         *   otherwise.
+         */
+        protected function _verifyLDAPLogin($username, $password)
+        {
+            // Assume failure.
+            $result = false;
+
+            // Make sure to use separate connection for verifying regular
+            // users. Do not reuse the control user connection.
+            $connection = @ldap_connect($this->getSetting('hostname'));
+
+            if ($connection !== false)
+            {
+                // Default LDAP protocol version used is 2, ensure we are
+                // using version 3 instead.
+                ldap_set_option($connection, LDAP_OPT_PROTOCOL_VERSION, 3);
+                ldap_set_option($connection, LDAP_OPT_REFERRALS, 0);
+
+                // Ignore PHP errors from this function (all PHP ldap_*
+                // functions misuse PHP error handling).
+                $result = @ldap_bind($connection, $username, $password);
+            }
+
+            return $result;
+        }
+
+
+        /**
+         * Creates or updates an existing user based on passed-in LDAP user
+         * information.
+         *
+         * @param array $ldap_user
+
+         *   Array describing the LDAP user. This is normally one of the
+         *   elements from _getLDAPUserInformation() method. The following keys
+         *   should be present in the array:
+         *
+         *   - ldap_username (LDAP user DN)
+         *   - username
+         *   - realname
+         *   - buddyname
+         *   - email
+         *
+         *
+         * @retval array
+         *   Returns an array with two elements. First element is instance of
+         *   \thebuggenie\core\entities\User, and second is a bool value
+         *   denoting if the user was created just now.
+         */
+        protected function _createOrUpdateUser($ldap_user)
+        {
+            $user = \thebuggenie\core\entities\User::getByUsername($ldap_user['username']);
+
+            if ($user instanceof \thebuggenie\core\entities\User)
+            {
+                $user->setRealname($ldap_user['realname']);
+                $user->setEmail($ldap_user['email']);
+                $user->setRealname($ldap_user['buddyname']);
+                $user->save();
+
+                $created = false;
+            }
+            else
+            {
+                $user = new \thebuggenie\core\entities\User();
+                $user->setUsername($ldap_user['username']);
+                $user->setRealname($ldap_user['realname']);
+                $user->setBuddyname($ldap_user['buddyname']);
+                $user->setEmail($ldap_user['email']);
+                $user->setEnabled();
+                $user->setActivated();
+                $user->setJoined();
+                $user->setPassword((openssl_random_pseudo_bytes(32)));
+                $user->save();
+
+                $created = true;
+            }
+
+            return [$user, $created];
+        }
+
+
+        /**
+         * Logs-in the user based on provided username and password, and
+         * retrieves the user entity.
+         *
+         * Initial logins are always verified against the LDAP directory, while
+         * subsequent ones are assumed to succeed automatically, since password
+         * will be in a hashed format that we cannot use for verification.
+         *
+         * @param string $username
+         *   Username to log-in with. Ignored if using HTTP integrated
+         *   authentication. This should be regular TBG username, not the LDAP
+         *   one (the LDAP one will be looked-up based on this value).
+         *
+         * @param string $password
+         *   Password to log-in with. Ignored if using HTTP integrated
+         *   authentication.
+         *
+         * @param bool $initial_login
+         *   Specify login mode. If initial login is requested, we will test
+         *   username and password against the LDAP server, otherwise it is
+         *   assumed that login has been performed before successfully.
+         *
+         * @retval \thebuggenie\core\entities\User | null
+         *   User entity if login was successful, null otherwise.
+         */
+        protected function _loginUser($username, $password, $initial_login)
+        {
+            // Retrieve LDAP user information.
+            $ldap_user_info = $this->_getLDAPUserInformation($username);
+
+            // If we could not locate user, return null to denote invalid login.
+            if (count($ldap_user_info) == 0)
+            {
+                return null;
+            }
+            // Bail-out if we locate more than one user, something is wrong with
+            // either module settings, or LDAP structure itself.
+            elseif (count($ldap_user_info) > 1)
+            {
+                framework\Logging::log("More than one user in LDAP directory has username '${username}'. Please verify integrity and structure of your LDAP installation.",
+                                       'ldap', framework\Logging::LEVEL_FATAL);
+                throw new \Exception(framework\Context::geti18n()->__('This user was found multiple times in the directory, please contact your administrator'));
+            }
+
+            // Extract user information.
+            $ldap_user = $ldap_user_info[0];
+
+            // Perform authentication based on whether we are using integrated
+            // authentication or not.
+            if ($this->getSetting('integrated_auth') == true && $initial_login === true)
+            {
+                if (!isset($_SERVER[$this->getSetting('integrated_auth_header')]) || $_SERVER[$this->getSetting('integrated_auth_header')] != $username)
+                {
+                    throw new \Exception(framework\Context::geti18n()->__('HTTP authentication internal error.'));
+                }
+            }
+            elseif ($initial_login === true)
+            {
+                $login_result = $this->_verifyLDAPLogin($ldap_user['ldap_username'], $password);
+
+                if ($login_result === false)
+                {
+                    return null;
+                }
+            }
+
+            // Create or update the existing user with up-to-date information.
+            list($user, $created) = $this->_createOrUpdateUser($ldap_user);
+
+            framework\Context::getResponse()->setCookie('tbg3_username', $username);
+            framework\Context::getResponse()->setCookie('tbg3_password', $user->getHashPassword());
+
+            return $user;
+        }
     }

--- a/modules/auth_ldap/Auth_ldap.php
+++ b/modules/auth_ldap/Auth_ldap.php
@@ -450,6 +450,10 @@
          * - Integrated authentication (if enabled).
          * - Availability of currently logged-in user in LDAP directory.
          *
+         * WARNING: Integrated authentication and availability of currently
+         * logged-in user in LDAP directory are not tested when this method is
+         * called from CLI.
+         *
          * @retval array
          *   Result of test. The following keys are available:
          *
@@ -511,7 +515,7 @@
 
                 // Verify that header is present if HTTP integrated
                 // authentication option is enabled.
-                if ($this->getSetting('integrated_auth'))
+                if (!framework\Context::isCLI() && $this->getSetting('integrated_auth'))
                 {
                     $header_field = $this->getSetting('integrated_auth_header');
 
@@ -521,13 +525,17 @@
                     }
                 }
 
-                // Verify that our current user can be located within the LDAP directory.
-                $current_username = framework\Context::getUser()->getUsername();
-                $ldap_users = $this->_getLDAPUserInformation($current_username);
-                if (count($ldap_users) != 1)
+                // Verify that our current user can be located within the LDAP
+                // directory. We don't have a user when in CLI.
+                if (!framework\Context::isCLI())
                 {
-                    throw new \Exception(framework\Context::geti18n()->__('Failed to locate current user (%username) in LDAP directory. If you enable LDAP authentication, you may find yourself locked-out of the settings. All other checks have passed.',
-                                                                          ['%username' => $current_username ]));
+                    $current_username = framework\Context::getUser()->getUsername();
+                    $ldap_users = $this->_getLDAPUserInformation($current_username);
+                    if (count($ldap_users) != 1)
+                    {
+                        throw new \Exception(framework\Context::geti18n()->__('Failed to locate current user (%username) in LDAP directory. If you enable LDAP authentication, you may find yourself locked-out of the settings. All other checks have passed.',
+                                                                              ['%username' => $current_username ]));
+                    }
                 }
             }
             catch (\Exception $e)

--- a/modules/auth_ldap/cli/Import.php
+++ b/modules/auth_ldap/cli/Import.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace thebuggenie\modules\auth_ldap\cli;
+use thebuggenie\core\framework;
+
+/**
+ * Implementation of CLI command for importing LDAP users into TBG.
+ *
+ * @author Branko Majic <branko@majic.rs>
+ * @version 4.2
+ * @license http://opensource.org/licenses/MPL-2.0 Mozilla Public License 2.0 (MPL 2.0)
+ * @package thebuggenie
+ * @subpackage auth_ldap
+ */
+
+
+/**
+ * CLI command for performing import of LDAP users into TBG.
+ *
+ * @package thebuggenie
+ * @subpackage auth_ldap
+ */
+class Import extends \thebuggenie\core\framework\cli\Command
+{
+    const ERROR = 1;
+
+    /**
+     * Sets-up the command name and description.
+     */
+    protected function _setup()
+    {
+        $this->_command_name = 'import';
+        $this->_description = 'Import new and update existing users based on user information from LDAP directory';
+    }
+
+    /**
+     * Executes the command.
+     *
+     */
+    public function do_execute()
+    {
+        $i18n = framework\Context::getI18n();
+
+        try
+        {
+            $statistics = framework\Context::getModule('auth_ldap')->importAndUpdateUsers();
+        }
+        catch (\Exception $e)
+        {
+            $this->cliEcho($i18n->__("Import failed") . ": " . $e->getMessage(), 'red');
+            $this->cliEcho("\n");
+            exit(self::ERROR);
+        }
+
+        $this->cliEcho($i18n->__('Import successful! Imported %imported users and updated %updated users out of total %total valid users found in LDAP',
+                                 ['%imported' => $statistics['imported'],
+                                  '%updated' => $statistics['updated'],
+                                  '%total' => $statistics['total']]));
+        $this->cliEcho("\n");
+    }
+}

--- a/modules/auth_ldap/cli/Prune.php
+++ b/modules/auth_ldap/cli/Prune.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace thebuggenie\modules\auth_ldap\cli;
+use thebuggenie\core\framework;
+
+/**
+ * Implementation of CLI command for pruning users missing in LDAP directory
+ * from TBG.
+ *
+ * @author Branko Majic <branko@majic.rs>
+ * @version 4.2
+ * @license http://opensource.org/licenses/MPL-2.0 Mozilla Public License 2.0 (MPL 2.0)
+ * @package thebuggenie
+ * @subpackage auth_ldap
+ */
+
+
+/**
+ * CLI command for pruning TBG users.
+ *
+ * @package thebuggenie
+ * @subpackage auth_ldap
+ */
+class Prune extends \thebuggenie\core\framework\cli\Command
+{
+    const ERROR = 1;
+
+    /**
+     * Sets-up the command name and description.
+     */
+    protected function _setup()
+    {
+        $this->_command_name = 'prune';
+        $this->_description = 'Remove all users from The Bug Genie that do not exist in LDAP directory. WARNING: This is a very dangerous operation, make sure you are confident in LDAP configuration before proceeding!';
+    }
+
+    /**
+     * Executes the command.
+     *
+     */
+    public function do_execute()
+    {
+        $i18n = framework\Context::getI18n();
+
+        try
+        {
+            $statistics = framework\Context::getModule('auth_ldap')->pruneUsers();
+        }
+        catch (\Exception $e)
+        {
+            $this->cliEcho($i18n->__("Pruning failed") . ": " . $e->getMessage(), 'red');
+            $this->cliEcho("\n");
+            exit(self::ERROR);
+        }
+
+
+        $this->cliEcho($i18n->__('Pruning successful! %deleted users deleted',
+                                 ['%deleted' => $statistics['deleted']]));
+        $this->cliEcho("\n");
+    }
+}

--- a/modules/auth_ldap/cli/Test.php
+++ b/modules/auth_ldap/cli/Test.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace thebuggenie\modules\auth_ldap\cli;
+use thebuggenie\core\framework;
+
+/**
+ * Implementation of CLI command for testing LDAP module connection and
+ * configuration.
+ *
+ * @author Branko Majic <branko@majic.rs>
+ * @version 4.2
+ * @license http://opensource.org/licenses/MPL-2.0 Mozilla Public License 2.0 (MPL 2.0)
+ * @package thebuggenie
+ * @subpackage auth_ldap
+ */
+
+
+/**
+ * CLI command for testing LDAP module connection and configuration.
+ *
+ * @package thebuggenie
+ * @subpackage auth_ldap
+ */
+class Test extends \thebuggenie\core\framework\cli\Command
+{
+    const ERROR = 1;
+
+    /**
+     * Sets-up the command name and description.
+     */
+    protected function _setup()
+    {
+        $this->_command_name = 'test';
+        $this->_description = 'Tests LDAP configuration and connectivity. WARNING: HTTP Integrated Authentication and availability of currently logged-in user cannot be tested in CLI!';
+    }
+
+    /**
+     * Executes the command.
+     *
+     */
+    public function do_execute()
+    {
+        $i18n = framework\Context::getI18n();
+
+        $result = framework\Context::getModule('auth_ldap')->testConnection();
+
+        if ($result['success'] === false)
+        {
+            $this->cliEcho($result['summary'] . ': ' . $result['details'], 'red');
+            $this->cliEcho("\n");
+            exit(self::ERROR);
+        }
+
+        $this->cliEcho($result['summary']);
+        $this->cliEcho("\n");
+    }
+}

--- a/modules/auth_ldap/controllers/Main.php
+++ b/modules/auth_ldap/controllers/Main.php
@@ -17,110 +17,17 @@
          */
         public function runTestConnection(framework\Request $request)
         {
-            $validgroups = framework\Context::getModule('auth_ldap')->getSetting('groups');
-            $base_dn = framework\Context::getModule('auth_ldap')->getSetting('b_dn');
-            $groups_members_attr = framework\Context::getModule('auth_ldap')->getSetting('g_attr');
-            $group_class = framework\Context::getModule('auth_ldap')->getSetting('g_type');
+            $result = framework\Context::getModule('auth_ldap')->testConnection();
 
-            try
+            if ($result === true)
             {
-                $connection = framework\Context::getModule('auth_ldap')->connect();
-
-                framework\Context::getModule('auth_ldap')->bind($connection, framework\Context::getModule('auth_ldap')->getSetting('control_user'), framework\Context::getModule('auth_ldap')->getSetting('control_pass'));
-            }
-            catch (\Exception $e)
-            {
-                framework\Context::setMessage('module_error', framework\Context::getI18n()->__('Failed to connect to server'));
-                framework\Context::setMessage('module_error_details', $e->getMessage());
+                framework\Context::setMessage('module_message', framework\Context::getI18n()->__('Connection test successful'));
                 $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
-            }
-
-            $nonexisting = array();
-
-            try
-            {
-                if ($validgroups != '')
-                {
-                    /*
-                     * We will repeat this for every group, but groups are supplied as a comma-separated list
-                     */
-                    if (strstr($validgroups, ','))
-                    {
-                        $groups = explode(',', $validgroups);
-                    }
-                    else
-                    {
-                        $groups = array();
-                        $groups[] = $validgroups;
-                    }
-
-                    // Check if specified groups exist
-                    foreach ($groups as $group)
-                    {
-                        /*
-                         * Find the group we are looking for, we search the entire directory
-                         * We want to find 1 group, if we don't get 1, silently ignore this group.
-                         */
-                        $fields2 = array($groups_members_attr);
-                        $filter2 = '(&(cn=' . framework\Context::getModule('auth_ldap')->escape($group) . ')(objectClass=' . framework\Context::getModule('auth_ldap')->escape($group_class) . '))';
-
-                        $results2 = ldap_search($connection, $base_dn, $filter2, $fields2);
-
-                        if (!$results2)
-                        {
-                            framework\Logging::log('failed to search for user: ' . ldap_error($connection), 'ldap', framework\Logging::LEVEL_FATAL);
-                            throw new \Exception(framework\Context::geti18n()->__('Search failed: ') . ldap_error($connection));
-                        }
-
-                        $data2 = ldap_get_entries($connection, $results2);
-
-                        if ($data2['count'] != 1)
-                        {
-                            $nonexisting[] = $group;
-                        }
-                    }
-                }
-            }
-            catch (\Exception $e)
-            {
-                ldap_unbind($connection);
-                framework\Context::setMessage('module_error', framework\Context::getI18n()->__('Failed to validate groups'));
-                framework\Context::setMessage('module_error_details', $e->getMessage());
-                $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
-            }
-
-            if (count($nonexisting) == 0)
-            {
-                ldap_unbind($connection);
-
-                /*
-                 * Test if REMOTE_USER header is being provided by web server if HTTP integrated authentication option is enabled.
-                 */
-                if (framework\Context::getModule('auth_ldap')->getSetting('integrated_auth'))
-                {
-                    if (!isset($_SERVER['REMOTE_USER']))
-                    {
-                        framework\Context::setMessage('module_error', framework\Context::getI18n()->__('HTTP Authentication Header not present'));
-                        framework\Context::setMessage('module_error_details', 'HTTP integrated authentication is enabled but the REMOTE_USER header is not being provided to Bug Genie. Please check your web server configuration');
-                        $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
-                    }
-                    else
-                    {
-                        framework\Context::setMessage('module_message', framework\Context::getI18n()->__('Connection test successful. HTTP integrated authentication states your username is "USER"', array('USER' => $_SERVER['REMOTE_USER'])));
-                        $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
-                    }
-                }
-                else
-                {
-                    framework\Context::setMessage('module_message', framework\Context::getI18n()->__('Connection test successful'));
-                    $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
-                }
             }
             else
             {
-                ldap_unbind($connection);
-                framework\Context::setMessage('module_error', framework\Context::getI18n()->__('Some of the groups you specified don\'t exist'));
-                framework\Context::setMessage('module_error_details', framework\Context::getI18n()->__('The following groups for the group restriction could not be found: %groups', array('%groups' => implode(', ', $nonexisting))));
+                framework\Context::setMessage('module_error', $result['summary']);
+                framework\Context::setMessage('module_error_details', $result['details']);
                 $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
             }
         }
@@ -132,127 +39,19 @@
          */
         public function runPruneUsers(framework\Request $request)
         {
-            $validgroups = framework\Context::getModule('auth_ldap')->getSetting('groups');
-            $base_dn = framework\Context::getModule('auth_ldap')->getSetting('b_dn');
-            $dn_attr = framework\Context::getModule('auth_ldap')->getSetting('dn_attr');
-            $username_attr = framework\Context::getModule('auth_ldap')->getSetting('u_attr');
-            $fullname_attr = framework\Context::getModule('auth_ldap')->getSetting('f_attr');
-            $email_attr = framework\Context::getModule('auth_ldap')->getSetting('e_attr');
-            $groups_members_attr = framework\Context::getModule('auth_ldap')->getSetting('g_attr');
-
-            $user_class = framework\Context::getModule('auth_ldap')->getSetting('u_type');
-            $group_class = framework\Context::getModule('auth_ldap')->getSetting('g_type');
-
-            $users = \thebuggenie\core\entities\User::getAll();
-            $deletecount = 0;
-
             try
             {
-                $connection = framework\Context::getModule('auth_ldap')->connect();
-                framework\Context::getModule('auth_ldap')->bind($connection, framework\Context::getModule('auth_ldap')->getSetting('control_user'), framework\Context::getModule('auth_ldap')->getSetting('control_pass'));
-
-                $default = framework\Settings::getDefaultUserID();
-
-                foreach ($users as $user)
-                {
-                    if ($user->getID() == $default)
-                    {
-                        continue;
-                    }
-
-                    $username = $user->getUsername();
-
-                    $fields = array($fullname_attr, $email_attr, 'cn', $dn_attr);
-                    $filter = '(&(objectClass=' . framework\Context::getModule('auth_ldap')->escape($user_class) . ')(' . $username_attr . '=' . framework\Context::getModule('auth_ldap')->escape($username) . '))';
-
-                    $results = ldap_search($connection, $base_dn, $filter, $fields);
-
-                    if (!$results)
-                    {
-                        framework\Logging::log('failed to search for user: ' . ldap_error($connection), 'ldap', framework\Logging::LEVEL_FATAL);
-                        throw new \Exception(framework\Context::geti18n()->__('Search failed: ') . ldap_error($connection));
-                    }
-
-                    $data = ldap_get_entries($connection, $results);
-
-                    /*
-                     * If a user is not found, delete it
-                     */
-                    if ($data['count'] != 1)
-                    {
-                        $user->delete();
-                        $deletecount++;
-                        continue;
-                    }
-
-                    if ($validgroups != '')
-                    {
-                        if (strstr($validgroups, ','))
-                        {
-                            $groups = explode(',', $validgroups);
-                        }
-                        else
-                        {
-                            $groups = array();
-                            $groups[] = $validgroups;
-                        }
-
-                        $allowed = false;
-
-                        foreach ($groups as $group)
-                        {
-                            $fields2 = array($groups_members_attr);
-                            $filter2 = '(&(objectClass=' . framework\Context::getModule('auth_ldap')->escape($group_class) . ')(cn=' . framework\Context::getModule('auth_ldap')->escape($group) . '))';
-
-                            $results2 = ldap_search($connection, $base_dn, $filter2, $fields2);
-
-                            if (!$results2)
-                            {
-                                framework\Logging::log('failed to search for user: ' . ldap_error($connection), 'ldap', framework\Logging::LEVEL_FATAL);
-                                throw new \Exception(framework\Context::geti18n()->__('Search failed: ') . ldap_error($connection));
-                            }
-
-                            $data2 = ldap_get_entries($connection, $results2);
-
-                            if ($data2['count'] != 1)
-                            {
-                                continue;
-                            }
-
-                            foreach ($data2[0][$groups_members_attr] as $member)
-                            {
-                                $member = preg_replace('/(?<=,) +(?=[a-zA-Z])/', '', $member);
-                                $user_dn = preg_replace('/(?<=,) +(?=[a-zA-Z])/', '', $data[0][strtolower($dn_attr)][0]);
-
-                                if (!is_numeric($member) && strtolower($member) == strtolower($user_dn))
-                                {
-                                    $allowed = true;
-                                }
-                            }
-                        }
-
-                        /*
-                         * If a user is not allowed access, delete it
-                         */
-                        if ($allowed == false)
-                        {
-                            $user->delete();
-                            $deletecount++;
-                            continue;
-                        }
-                    }
-                }
+                $statistics = framework\Context::getModule('auth_ldap')->pruneUsers();
             }
             catch (\Exception $e)
             {
-                ldap_unbind($connection);
                 framework\Context::setMessage('module_error', framework\Context::getI18n()->__('Pruning failed'));
                 framework\Context::setMessage('module_error_details', $e->getMessage());
                 $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
             }
 
-            ldap_unbind($connection);
-            framework\Context::setMessage('module_message', framework\Context::getI18n()->__('Pruning successful! %del users deleted', array('%del' => $deletecount)));
+            framework\Context::setMessage('module_message', framework\Context::getI18n()->__('Pruning successful! %deleted users deleted',
+                                                                                             ['%deleted' => $statistics['deleted']]));
             $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
         }
 
@@ -263,156 +62,9 @@
          */
         public function runImportUsers(framework\Request $request)
         {
-            $validgroups = framework\Context::getModule('auth_ldap')->getSetting('groups');
-            $base_dn = framework\Context::getModule('auth_ldap')->getSetting('b_dn');
-            $dn_attr = framework\Context::getModule('auth_ldap')->getSetting('dn_attr');
-            $username_attr = framework\Context::getModule('auth_ldap')->getSetting('u_attr');
-            $fullname_attr = framework\Context::getModule('auth_ldap')->getSetting('f_attr');
-            $buddyname_attr = framework\Context::getModule('auth_ldap')->getSetting('b_attr');
-            $email_attr = framework\Context::getModule('auth_ldap')->getSetting('e_attr');
-            $groups_members_attr = framework\Context::getModule('auth_ldap')->getSetting('g_attr');
-
-            $user_class = framework\Context::getModule('auth_ldap')->getSetting('u_type');
-            $group_class = framework\Context::getModule('auth_ldap')->getSetting('g_type');
-
-            $users = array();
-            $importcount = 0;
-            $updatecount = 0;
-
             try
             {
-                /*
-                 * Connect and bind to the control user
-                 */
-                $connection = framework\Context::getModule('auth_ldap')->connect();
-                framework\Context::getModule('auth_ldap')->bind($connection, framework\Context::getModule('auth_ldap')->getSetting('control_user'), framework\Context::getModule('auth_ldap')->getSetting('control_pass'));
-
-                /*
-                 * Get a list of all users of a certain objectClass
-                 */
-                $fields = array($fullname_attr, $buddyname_attr, $username_attr, $email_attr, 'cn', $dn_attr);
-                $filter = '(objectClass=' . framework\Context::getModule('auth_ldap')->escape($user_class) . ')';
-
-                $results = ldap_search($connection, $base_dn, $filter, $fields);
-                if (!$results)
-                {
-                    framework\Logging::log('failed to search for users: ' . ldap_error($connection), 'ldap', framework\Logging::LEVEL_FATAL);
-                    throw new \Exception(framework\Context::geti18n()->__('Search failed: ') . ldap_error($connection));
-                }
-
-                $data = ldap_get_entries($connection, $results);
-
-                /*
-                 * For every user that exists, process it.
-                 */
-                for ($i = 0; $i != $data['count']; $i++)
-                {
-                    $user_dn = $data[$i][strtolower($dn_attr)][0];
-
-                    /*
-                     * If groups are specified, perform group restriction tests
-                     */
-                    if ($validgroups != '')
-                    {
-                        /*
-                         * We will repeat this for every group, but groups are supplied as a comma-separated list
-                         */
-                        if (strstr($validgroups, ','))
-                        {
-                            $groups = explode(',', $validgroups);
-                        }
-                        else
-                        {
-                            $groups = array();
-                            $groups[] = $validgroups;
-                        }
-
-                        // Assumed we are initially banned
-                        $allowed = false;
-
-                        foreach ($groups as $group)
-                        {
-                            // No need to carry on looking if we have access
-                            if ($allowed == true): continue;
-                            endif;
-
-                            /*
-                             * Find the group we are looking for, we search the entire directory
-                             * We want to find 1 group, if we don't get 1, silently ignore this group.
-                             */
-                            $fields2 = array($groups_members_attr);
-                            $filter2 = '(&(cn=' . framework\Context::getModule('auth_ldap')->escape($group) . ')(objectClass=' . framework\Context::getModule('auth_ldap')->escape($group_class) . '))';
-
-                            $results2 = ldap_search($connection, $base_dn, $filter2, $fields2);
-
-                            if (!$results2)
-                            {
-                                framework\Logging::log('failed to search for user: ' . ldap_error($connection), 'ldap', framework\Logging::LEVEL_FATAL);
-                                throw new \Exception(framework\Context::geti18n()->__('Search failed: ') . ldap_error($connection));
-                            }
-
-                            $data2 = ldap_get_entries($connection, $results2);
-
-                            if ($data2['count'] != 1)
-                            {
-                                continue;
-                            }
-
-                            /*
-                             * Look through the group's member list. If we are found, grant access.
-                             */
-                            foreach ($data2[0][strtolower($groups_members_attr)] as $member)
-                            {
-                                $member = preg_replace('/(?<=,) +(?=[a-zA-Z])/', '', $member);
-                                $user_dn = preg_replace('/(?<=,) +(?=[a-zA-Z])/', '', $user_dn);
-                                if (!is_numeric($member) && strtolower($member) == strtolower($user_dn))
-                                {
-                                    $allowed = true;
-                                }
-                            }
-                        }
-
-                        if ($allowed == false)
-                        {
-                            continue;
-                        }
-                    }
-
-                    $users[$i] = array();
-
-                    /*
-                     * Set user's properties.
-                     * Realname is obtained from directory, if not found we set it to the username
-                     * Email is obtained from directory, if not found we set it to blank
-                     */
-                    if (!array_key_exists(strtolower($fullname_attr), $data[$i]))
-                    {
-                        $users[$i]['realname'] = $data[$i]['cn'][0];
-                    }
-                    else
-                    {
-                        $users[$i]['realname'] = $data[$i][strtolower($fullname_attr)][0];
-                    }
-
-                    if (!array_key_exists(strtolower($buddyname_attr), $data[$i]))
-                    {
-                        $users[$i]['buddyname'] = $data[$i]['cn'][0];
-                    }
-                    else
-                    {
-                        $users[$i]['buddyname'] = $data[$i][strtolower($buddyname_attr)][0];
-                    }
-
-                    if (!array_key_exists(strtolower($email_attr), $data[$i]))
-                    {
-                        $users[$i]['email'] = '';
-                    }
-                    else
-                    {
-                        $users[$i]['email'] = $data[$i][strtolower($email_attr)][0];
-                    }
-                    $users[$i]['username'] = $data[$i][strtolower($username_attr)][0];
-                }
+                $statistics = framework\Context::getModule('auth_ldap')->importAndUpdateUsers();
             }
             catch (\Exception $e)
             {
@@ -421,54 +73,13 @@
                 $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
             }
 
-            /*
-             * For every user that was found, either create a new user object, or update
-             * the existing one. This will update the created and updated counts as appropriate.
-             */
-            foreach ($users as $ldapuser)
-            {
-                $username = $ldapuser['username'];
-                $email = $ldapuser['email'];
-                $realname = $ldapuser['realname'];
-                $buddyname = $ldapuser['buddyname'];
+            framework\Context::setMessage(
+                'module_message',
+                framework\Context::getI18n()->__('Import successful! Imported %imported users and updated %updated users out of total %total valid users found in LDAP',
+                                                 ['%imported' => $statistics['imported'],
+                                                  '%updated' => $statistics['updated'],
+                                                  '%total' => $statistics['total']]));
 
-                try
-                {
-                    $user = \thebuggenie\core\entities\User::getByUsername($username);
-                    if ($user instanceof \thebuggenie\core\entities\User)
-                    {
-                        $user->setRealname($realname);
-                        $user->setEmail($email); // update email address
-                        $user->save();
-                        $updatecount++;
-                    }
-                    else
-                    {
-                        // create user
-                        $user = new \thebuggenie\core\entities\User();
-                        $user->setUsername($username);
-                        $user->setRealname($realname);
-                        $user->setBuddyname($buddyname);
-                        $user->setEmail($email);
-                        $user->setEnabled();
-                        $user->setActivated();
-                        $user->setPassword($user->getJoinedDate() . $username);
-                        $user->setJoined();
-                        $user->save();
-                        $importcount++;
-                    }
-                }
-                catch (\Exception $e)
-                {
-                    ldap_unbind($connection);
-                    framework\Context::setMessage('module_error', framework\Context::getI18n()->__('Import failed'));
-                    framework\Context::setMessage('module_error_details', $e->getMessage());
-                    $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
-                }
-            }
-
-            ldap_unbind($connection);
-            framework\Context::setMessage('module_message', framework\Context::getI18n()->__('Import successful! %imp users imported, %upd users updated from LDAP', array('%imp' => $importcount, '%upd' => $updatecount)));
             $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
         }
 

--- a/modules/auth_ldap/controllers/Main.php
+++ b/modules/auth_ldap/controllers/Main.php
@@ -19,9 +19,9 @@
         {
             $result = framework\Context::getModule('auth_ldap')->testConnection();
 
-            if ($result === true)
+            if ($result['success'] === true)
             {
-                framework\Context::setMessage('module_message', framework\Context::getI18n()->__('Connection test successful'));
+                framework\Context::setMessage('module_message', $result['summary']);
                 $this->forward(framework\Context::getRouting()->generate('configure_module', array('config_module' => 'auth_ldap')));
             }
             else

--- a/modules/auth_ldap/templates/_settings.inc.php
+++ b/modules/auth_ldap/templates/_settings.inc.php
@@ -18,14 +18,14 @@
             <div class="header"><?= __('Connection details'); ?></div>
             <table style="width: 680px;" class="padded_table" cellpadding=0 cellspacing=0 id="ldap_settings_table">
                 <tr>
-                    <td style="padding: 5px;"><label for="hostname"><?= __('LDAP connection URI'); ?></label></td>
+                    <td style="padding: 5px;"><label for="hostname"><strong><?= __('LDAP connection URI'); ?></strong></label></td>
                     <td><input type="text" name="hostname" id="hostname" value="<?= $module->getSetting('hostname'); ?>" style="width: 100%;"></td>
                 </tr>
                 <tr>
                     <td class="config_explanation" colspan="2"><?= __('URI used for connecting to the LDAP server. Format is <schema://[name[:port]]/>, where schema is one of: ldap (plain-text), ldaps (TLS connection), or ldapi (UNIX domain socket). For example: ldap://hostname/, ldap://hostname:1389/, ldaps://hostname:636/, ldaps://hostname:1636/, ldapi:///.'); ?></td>
                 </tr>
                 <tr>
-                    <td style="padding: 5px;"><label for="b_dn"><?= __('Base DN'); ?></label></td>
+                    <td style="padding: 5px;"><label for="b_dn"><strong><?= __('Base DN'); ?></strong></label></td>
                     <td><input type="text" name="b_dn" id="b_dn" value="<?= $module->getSetting('b_dn'); ?>" style="width: 100%;"></td>
                 </tr>
                 <tr>
@@ -60,21 +60,21 @@
                     <td class="config_explanation" colspan="2"><?= __('HTTP header field containing the username if HTTP Integrated Authentication is enabled. For example: REMOTE_USER.'); ?></td>
                 </tr>
                 <tr>
-                    <td style="padding: 5px;"><label for="dn_attr"><?= __('Object DN attribute'); ?></label></td>
+                    <td style="padding: 5px;"><label for="dn_attr"><strong><?= __('Object DN attribute'); ?></strong></label></td>
                     <td><input type="text" name="dn_attr" id="dn_attr" value="<?= $module->getSetting('dn_attr'); ?>" style="width: 100%;"></td>
                 </tr>
                 <tr>
                     <td class="config_explanation" colspan="2"><?= __('LDAP attribute that contains the distinguished name of an object. On most LDAP servers this shouild be set to entrydn. If using Active Directory, set the value to distinguishedName.'); ?></td>
                 </tr>
                 <tr>
-                    <td style="padding: 5px;"><label for="u_type"><?= __('User object class'); ?></label></td>
+                    <td style="padding: 5px;"><label for="u_type"><strong><?= __('User object class'); ?></strong></label></td>
                     <td><input type="text" name="u_type" id="u_type" value="<?= $module->getSetting('u_type'); ?>" style="width: 100%;"></td>
                 </tr>
                 <tr>
                     <td class="config_explanation" colspan="2"><?= __('Object class used for locating valid user entries. For example: person, inetOrgPerson.'); ?></td>
                 </tr>
                 <tr>
-                    <td style="padding: 5px;"><label for="u_attr"><?= __('User username attribute'); ?></label></td>
+                    <td style="padding: 5px;"><label for="u_attr"><strong><?= __('User username attribute'); ?></strong></label></td>
                     <td><input type="text" name="u_attr" id="u_attr" value="<?= $module->getSetting('u_attr'); ?>" style="width: 100%;"></td>
                 </tr>
                 <tr>

--- a/modules/auth_ldap/templates/_settings.inc.php
+++ b/modules/auth_ldap/templates/_settings.inc.php
@@ -121,7 +121,7 @@
 <form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo make_url('ldap_test'); ?>" method="post">
     <div class="rounded_box borderless mediumgrey cut_bottom" style="margin: 10px 0 0 0; width: 700px; padding: 5px;">
         <div class="header"><?php echo __('Test connection'); ?></div>
-        <div class="content"><?php echo __('After configuring and saving your connection settings, you should test your connection to the LDAP server. This test does not check whether the DN and attributes can allow The Bug Genie to correctly find users, but it will give an indication if The Bug Genie can talk to your LDAP server, and if any groups you specify exist. If HTTP integrated authentication is enabled, this will also test that your web server is providing the REMOTE_USER header.'); ?></div>
+        <div class="content"><?php echo __('After configuring and saving your connection settings, you should test your connection to the LDAP server. This test does not check whether the DN and attributes can allow The Bug Genie to correctly find users, but it will give an indication if The Bug Genie can talk to your LDAP server, and if any groups you specify exist. If HTTP integrated authentication is enabled, this will also test that your web server is providing the configured header.'); ?></div>
     </div>
     <div class="rounded_box iceblue borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
         <input type="submit" id="test_button"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> style="float: right; padding: 0 10px 0 10px; font-size: 13px; font-weight: bold;" value="<?php echo __('Test connection'); ?>">

--- a/modules/auth_ldap/templates/_settings.inc.php
+++ b/modules/auth_ldap/templates/_settings.inc.php
@@ -1,149 +1,164 @@
-<p><?php echo __('Use this page to set up the connection details for your LDAP or Active Directory server. It is highly recommended that you read the online help before use, as misconfiguration may prevent you from accessing configuration pages to rectify issues.'); ?></p>
-<p><b><?php echo link_tag('http://issues.thebuggenie.com/wiki/Category%3ATheBugGenie%3AUserGuide%3AModules%3ALDAP', __('View the online documentation')); ?></b></p>
+<p><?= __('Use this page to set up the connection details for your LDAP or Active Directory server. It is highly recommended that you read the online help before use, as misconfiguration may prevent you from accessing configuration pages to rectify issues.'); ?></p>
+
+<p><b><?= link_tag('http://issues.thebuggenie.com/wiki/Category%3ATheBugGenie%3AUserGuide%3AModules%3ALDAP', __('View the online documentation')); ?></b></p>
+
 <?php if ($noldap): ?>
-<div class="rounded_box red" style="margin-top: 5px">
-    <div class="header"><?php echo __('LDAP support is not installed'); ?></div>
-    <p><?php echo __('The PHP LDAP extension is required to use this functionality. As this module is not installed, all functionality on this page has been disabled.'); ?></p>
-</div>
+    <div class="rounded_box red" style="margin-top: 5px">
+        <div class="header"><?= __('LDAP support is not installed'); ?></div>
+        <p><?= __('The PHP LDAP extension is required to use this functionality. As this module is not installed, all functionality on this page has been disabled.'); ?></p>
+    </div>
+<?php else: ?>
+    <div class="rounded_box yellow" style="margin-top: 5px">
+        <div class="header"><?= __('Important information'); ?></div>
+        <p><?= __('When you enable LDAP as your authentication backend in Authentication configuration, you will lose access to all accounts which do not also exist in the LDAP database. This may mean you lose administrative access.'); ?></p>
+        <p style="font-weight: bold; padding-top: 5px"><?= __('To resolve this issue, either import all users using the tool on this page and make one an administrator using Users configuration, or create a user with the same username as one in LDAP and make that one an administrator.'); ?></p>
+    </div>
+    <form accept-charset="<?= \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?= make_url('configure_module', array('config_module' => $module->getName())); ?>" enctype="multipart/form-data" method="post">
+        <div class="rounded_box borderless mediumgrey<?php if ($access_level == \thebuggenie\core\framework\Settings::ACCESS_FULL): ?> cut_bottom<?php endif; ?>" style="margin: 10px 0 0 0; width: 700px;<?php if ($access_level == \thebuggenie\core\framework\Settings::ACCESS_FULL): ?> border-bottom: 0;<?php endif; ?>">
+            <div class="header"><?= __('Connection details'); ?></div>
+            <table style="width: 680px;" class="padded_table" cellpadding=0 cellspacing=0 id="ldap_settings_table">
+                <tr>
+                    <td style="padding: 5px;"><label for="hostname"><?= __('LDAP connection URI'); ?></label></td>
+                    <td><input type="text" name="hostname" id="hostname" value="<?= $module->getSetting('hostname'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('URI used for connecting to the LDAP server. Format is <schema://[name[:port]]/>, where schema is one of: ldap (plain-text), ldaps (TLS connection), or ldapi (UNIX domain socket). For example: ldap://hostname/, ldap://hostname:1389/, ldaps://hostname:636/, ldaps://hostname:1636/, ldapi:///.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="b_dn"><?= __('Base DN'); ?></label></td>
+                    <td><input type="text" name="b_dn" id="b_dn" value="<?= $module->getSetting('b_dn'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('Base DN under which all user and group entires can be found. For example: dc=ldap,c=example,dc=com.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="control_user"><?= __('Control user DN'); ?></label></td>
+                    <td><input type="text" name="control_user" id="control_user" value="<?= $module->getSetting('control_user'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('LDAP distinguished name (DN) for control user. Control user needs to be able to access all relevant user and allowed group entries in the LDAP directory. Read-only access is sufficient. The user does not need to be able to read any credentials (passwords). To use anonymous bind for control user, leave the setting blank. For example: cn=tbg,ou=services,c=example,dc=com.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="control_pass"><?= __('Control user password'); ?></label></td>
+                    <td><input type="password" name="control_pass" id="control_pass" value="<?= $module->getSetting('control_pass'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('Password for logging in into LDAP directory using the control user DN. To use anonymous bind for control user, leave the setting blank.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="integrated_auth"><?= __('Use HTTP Integrated Authentication'); ?></label></td>
+                    <td><input type="checkbox" name="integrated_auth" id="integrated_auth" value="1" value="1" <?php if ($module->getSetting('integrated_auth')): ?>checked<?php endif; ?> style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('Enable automated login by using username passed-in into application via HTTP header. This requires that the web server performs authentication on behalf of The Bug Genie (e.g. HTTP Basic Authentication, Kerberos etc).'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="integrated_auth_header"><?= __('HTTP header field'); ?></label></td>
+                    <td><input type="text" name="integrated_auth_header" id="integrated_auth_header" value="<?= $module->getSetting('integrated_auth_header'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('HTTP header field containing the username if HTTP Integrated Authentication is enabled. For example: REMOTE_USER.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="dn_attr"><?= __('Object DN attribute'); ?></label></td>
+                    <td><input type="text" name="dn_attr" id="dn_attr" value="<?= $module->getSetting('dn_attr'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('LDAP attribute that contains the distinguished name of an object. On most LDAP servers this shouild be set to entrydn. If using Active Directory, set the value to distinguishedName.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="u_type"><?= __('User object class'); ?></label></td>
+                    <td><input type="text" name="u_type" id="u_type" value="<?= $module->getSetting('u_type'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('Object class used for locating valid user entries. For example: person, inetOrgPerson.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="u_attr"><?= __('User username attribute'); ?></label></td>
+                    <td><input type="text" name="u_attr" id="u_attr" value="<?= $module->getSetting('u_attr'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('LDAP attribute where the username is stored. For example: uid.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="f_attr"><?= __('User full name attribute'); ?></label></td>
+                    <td><input type="text" name="f_attr" id="f_attr" value="<?= $module->getSetting('f_attr'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('LDAP attribute where the full name of the user is stored. If not specified, cn will be used if available. For example: displayName.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="b_attr"><?= __('User buddy name attribute'); ?></label></td>
+                    <td><input type="text" name="b_attr" id="b_attr" value="<?= $module->getSetting('b_attr'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('LDAP attribute where the buddy name is stored. For example: gn.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="e_attr"><?= __('User e-mail address attribute'); ?></label></td>
+                    <td><input type="text" name="e_attr" id="e_attr" value="<?= $module->getSetting('e_attr'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('LDAP attribute where the e-mail is stored. For example: mail.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="groups"><?= __('Allowed groups'); ?></label></td>
+                    <td><input type="text" name="groups" id="groups" value="<?= $module->getSetting('groups'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('Comma-separated list of allowed groups. Each group should be specified by its common name (cn) attribute. If specified, only users that are members of these groups will be able to access The Bug Genie. Leave this option blank to disable group membership checks and allow any valid LDAP user to access The Bug Genie. For example: tbg,mygroup1,mygroup2.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="g_type"><?= __('Group object class'); ?></label></td>
+                    <td><input type="text" name="g_type" id="g_type" value="<?= $module->getSetting('g_type'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('Object class used for locating valid allowed group entries. For example: groupOfNames, groupOfUniqueNames.'); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding: 5px;"><label for="g_attr"><?= __('Group member attribute'); ?></label></td>
+                    <td><input type="text" name="g_attr" id="g_attr" value="<?= $module->getSetting('g_attr'); ?>" style="width: 100%;"></td>
+                </tr>
+                <tr>
+                    <td class="config_explanation" colspan="2"><?= __('LDAP attribute in allowed group entries where member users are stored. For example: member, uniqueMember.'); ?></td>
+                </tr>
+            </table>
+        </div>
+        <?php if ($access_level == \thebuggenie\core\framework\Settings::ACCESS_FULL): ?>
+            <div class="rounded_box iceblue borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
+                <div style="float: left; font-size: 13px; padding-top: 2px;"><?= __('Click "%save" to save the settings', array('%save' => __('Save'))); ?></div>
+                <input type="submit" id="submit_settings_button" style="float: right; padding: 0 10px 0 10px; font-size: 14px; font-weight: bold;" value="<?= __('Save'); ?>">
+            </div>
+        <?php endif; ?>
+    </form>
+
+    <form accept-charset="<?= \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?= make_url('ldap_test'); ?>" method="post">
+        <div class="rounded_box borderless mediumgrey cut_bottom" style="margin: 10px 0 0 0; width: 700px; padding: 5px;">
+            <div class="header"><?= __('Test connection'); ?></div>
+            <div class="content"><?= __('After configuring and saving your connection settings, you should test your connection to the LDAP server. This test does not check whether the DN and attributes can allow The Bug Genie to correctly find users, but it will give an indication if The Bug Genie can talk to your LDAP server, and if any groups you specify exist. If HTTP integrated authentication is enabled, this will also test that your web server is providing the configured header.'); ?></div>
+        </div>
+        <div class="rounded_box iceblue borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
+            <input type="submit" id="test_button" style="float: right; padding: 0 10px 0 10px; font-size: 13px; font-weight: bold;" value="<?= __('Test connection'); ?>">
+        </div>
+    </form>
+
+    <form accept-charset="<?= \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?= make_url('ldap_import'); ?>" method="post">
+        <div class="rounded_box borderless mediumgrey cut_bottom" style="margin: 10px 0 0 0; width: 700px; padding: 5px;">
+            <div class="header"><?= __('Import all users'); ?></div>
+            <div class="content"><?= __('You can import all users who can log in from LDAP into The Bug Genie with this tool. This will not let them log in without switching to LDAP Authentication. We recomemnd you do this before switching over, and make at least one of the new users an administrator. Already existing users with the same username will be updated.'); ?></div>
+        </div>
+        <div class="rounded_box iceblue borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
+            <input type="submit" id="import_button" style="float: right; padding: 0 10px 0 10px; font-size: 13px; font-weight: bold;" value="<?= __('Import users'); ?>">
+        </div>
+    </form>
+
+    <form accept-charset="<?= \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?= make_url('ldap_prune'); ?>" method="post">
+        <div class="rounded_box borderless mediumgrey cut_bottom" style="margin: 10px 0 0 0; width: 700px; padding: 5px;">
+            <div class="header"><?= __('Prune users'); ?></div>
+            <div class="content"><?= __('To remove the data from The Bug Genie of users who can no longer log in via LDAP, run this tool. These users would not be able to log in anyway, but it will keep your user list clean. The guest user is not affected, but it may affect your current user - if this is deleted you will be logged out.'); ?></div>
+        </div>
+        <div class="rounded_box red borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
+            <input type="submit" id="prune_button" style="float: right; padding: 0 10px 0 10px; font-size: 13px; font-weight: bold;" value="<?= __('Prune users'); ?>">
+        </div>
+    </form>
 <?php endif; ?>
-<div class="rounded_box yellow" style="margin-top: 5px">
-    <div class="header"><?php echo __('Important information'); ?></div>
-    <p><?php echo __('When you enable LDAP as your authentication backend in Authentication configuration, you will lose access to all accounts which do not also exist in the LDAP database. This may mean you lose administrative access.'); ?></p>
-    <p style="font-weight: bold; padding-top: 5px"><?php echo __('To resolve this issue, either import all users using the tool on this page and make one an administrator using Users configuration, or create a user with the same username as one in LDAP and make that one an administrator.'); ?></p>
-</div>
-<form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo make_url('configure_module', array('config_module' => $module->getName())); ?>" enctype="multipart/form-data" method="post">
-    <div class="rounded_box borderless mediumgrey<?php if ($access_level == \thebuggenie\core\framework\Settings::ACCESS_FULL): ?> cut_bottom<?php endif; ?>" style="margin: 10px 0 0 0; width: 700px;<?php if ($access_level == \thebuggenie\core\framework\Settings::ACCESS_FULL): ?> border-bottom: 0;<?php endif; ?>">
-        <div class="header"><?php echo __('Connection details'); ?></div>
-        <table style="width: 680px;" class="padded_table" cellpadding=0 cellspacing=0 id="ldap_settings_table">
-            <tr>
-                <td style="padding: 5px;"><label for="hostname"><?php echo __('Hostname'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="hostname" id="hostname" value="<?php echo $module->getSetting('hostname'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('Use URL syntax (ldap://hostname:port). If your server requires SSL, use ldaps://hostname/ in this field.'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="b_dn"><?php echo __('Base DN'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="b_dn" id="b_dn" value="<?php echo $module->getSetting('b_dn'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('This should be the DN string for an OU where all user and group OUs can be found. For example, DC=ldap,DC=example,DC=com.'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="dn_attr"><?php echo __('Object DN attribute'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="dn_attr" id="dn_attr" value="<?php echo $module->getSetting('dn_attr'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('Enter the name of the property containing the distinguished name of an object. On Linux systems this may be entrydn (which is the default value if this is left blank), on Active Directory it is distinguishedName.'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="u_type"><?php echo __('User class'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="u_type" id="u_type" value="<?php echo $module->getSetting('u_type'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('Enter the value to check for in objectClass for users. Leave blank to use the default of person'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="u_attr"><?php echo __('Username attribute'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="u_attr" id="u_attr" value="<?php echo $module->getSetting('u_attr'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('This field should contain the name of the attribute where the username is stored, such as uid.'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="f_attr"><?php echo __('Full name attribute'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="f_attr" id="f_attr" value="<?php echo $module->getSetting('f_attr'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="b_attr"><?php echo __('Given name attribute'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="b_attr" id="b_attr" value="<?php echo $module->getSetting('b_attr'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="e_attr"><?php echo __('Email address attribute'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="e_attr" id="e_attr" value="<?php echo $module->getSetting('e_attr'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="g_type"><?php echo __('Group class'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="g_type" id="g_type" value="<?php echo $module->getSetting('g_type'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('Enter the value to check for in objectClass for groups. Leave blank to use the default of group'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="g_attr"><?php echo __('Group members attribute'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="g_attr" id="g_attr" value="<?php echo $module->getSetting('g_attr'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('This field should contain the name of the attribute where the list of members of a group is stored, such as uniqueMember.'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="groups"><?php echo __('Allowed groups'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="groups" id="groups" value="<?php echo $module->getSetting('groups'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('You may wish to restrict access to users who belong to certain groups in LDAP. If so, write a comma separated list of group names here. Leave blank to disable this feature.'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="control_user"><?php echo __('Control username'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="control_user" id="control_user" value="<?php echo $module->getSetting('control_user'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="control_pass"><?php echo __('Control user password'); ?></label></td>
-                <td><input type="password"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="control_pass" id="control_pass" value="<?php echo $module->getSetting('control_pass'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('Please insert the authentication details for a user who can access all LDAP records. Only read only access is necessary, and for an anonyous bind leave this blank.'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="integrated_auth"><?php echo __('Use HTTP Integrated Authentication'); ?></label></td>
-                <td><input type="checkbox"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="integrated_auth" id="integrated_auth" value="1" value="1" <?php if ($module->getSetting('integrated_auth')): ?>checked<?php endif; ?> style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('Activate to enabled automatic user login using HTTP integrated authentication. This requires your web server to be authenticating the user (e.g. HTTP Basic Authentication, Kerberos etc).'); ?></td>
-            </tr>
-            <tr>
-                <td style="padding: 5px;"><label for="integrated_auth_header"><?php echo __('HTTP header field'); ?></label></td>
-                <td><input type="text"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> name="integrated_auth_header" id="integrated_auth_header" value="<?php echo $module->getSetting('integrated_auth_header'); ?>" style="width: 100%;"></td>
-            </tr>
-            <tr>
-                <td class="config_explanation" colspan="2"><?php echo __('If using HTTP integrated authentication specify the HTTP header field that will contain the user name.'); ?></td>
-            </tr>                                    
-        </table>
-    </div>
-<?php if ($access_level == \thebuggenie\core\framework\Settings::ACCESS_FULL): ?>
-    <div class="rounded_box iceblue borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
-        <div style="float: left; font-size: 13px; padding-top: 2px;"><?php echo __('Click "%save" to save the settings', array('%save' => __('Save'))); ?></div>
-        <input type="submit" id="submit_settings_button"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> style="float: right; padding: 0 10px 0 10px; font-size: 14px; font-weight: bold;" value="<?php echo __('Save'); ?>">
-    </div>
-<?php endif; ?>
-</form>
-
-<form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo make_url('ldap_test'); ?>" method="post">
-    <div class="rounded_box borderless mediumgrey cut_bottom" style="margin: 10px 0 0 0; width: 700px; padding: 5px;">
-        <div class="header"><?php echo __('Test connection'); ?></div>
-        <div class="content"><?php echo __('After configuring and saving your connection settings, you should test your connection to the LDAP server. This test does not check whether the DN and attributes can allow The Bug Genie to correctly find users, but it will give an indication if The Bug Genie can talk to your LDAP server, and if any groups you specify exist. If HTTP integrated authentication is enabled, this will also test that your web server is providing the configured header.'); ?></div>
-    </div>
-    <div class="rounded_box iceblue borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
-        <input type="submit" id="test_button"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> style="float: right; padding: 0 10px 0 10px; font-size: 13px; font-weight: bold;" value="<?php echo __('Test connection'); ?>">
-    </div>
-</form>
-
-<form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo make_url('ldap_import'); ?>" method="post">
-    <div class="rounded_box borderless mediumgrey cut_bottom" style="margin: 10px 0 0 0; width: 700px; padding: 5px;">
-        <div class="header"><?php echo __('Import all users'); ?></div>
-        <div class="content"><?php echo __('You can import all users who can log in from LDAP into The Bug Genie with this tool. This will not let them log in without switching to LDAP Authentication. We recomemnd you do this before switching over, and make at least one of the new users an administrator. Already existing users with the same username will be updated.'); ?></div>
-    </div>
-    <div class="rounded_box iceblue borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
-        <input type="submit" id="import_button"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> style="float: right; padding: 0 10px 0 10px; font-size: 13px; font-weight: bold;" value="<?php echo __('Import users'); ?>">
-    </div>
-</form>
-
-<form accept-charset="<?php echo \thebuggenie\core\framework\Context::getI18n()->getCharset(); ?>" action="<?php echo make_url('ldap_prune'); ?>" method="post">
-    <div class="rounded_box borderless mediumgrey cut_bottom" style="margin: 10px 0 0 0; width: 700px; padding: 5px;">
-        <div class="header"><?php echo __('Prune users'); ?></div>
-        <div class="content"><?php echo __('To remove the data from The Bug Genie of users who can no longer log in via LDAP, run this tool. These users would not be able to log in anyway, but it will keep your user list clean. The guest user is not affected, but it may affect your current user - if this is deleted you will be logged out.'); ?></div>
-    </div>
-    <div class="rounded_box red borderless cut_top" style="margin: 0 0 5px 0; width: 700px; border-top: 0; padding: 8px 5px 2px 5px; height: 25px;">
-        <input type="submit"<?php if ($noldap): echo ' disabled="disabled"'; endif; ?> id="prune_button" style="float: right; padding: 0 10px 0 10px; font-size: 13px; font-weight: bold;" value="<?php echo __('Prune users'); ?>">
-    </div>
-</form>


### PR DESCRIPTION
This set of changes involves some major refactoring of the LDAP module code. The following major changes are included:

- Update to error handler in core to ignore suppressed PHP errors (commands where `@` operator is used).
- Update to handling of auto-login functionality in the core.
- Updated to LDAP structure for Vagrant/Ansible dev machine in order to provide more variety for testing LDAP.
- Business logic in LDAP module has been moved outside of controller and into the module class making it more easily accessible elsewhere in the code.
- Business logic has been rewritten to be more resilient, better structured, and with less duplication of code.
- Removed defaults for a number of settings. These were applied during the save operation automatically, which could look confusing (you save one set of things on the page, you view different set of things on the redirect).
- Expanded connection testing to cover counting users available and to check if currently logged-in user is available in LDAP directory as well. Should help reduce chance of getting locked-out.
- Settings page has been updated to have better help that matches LDAP terminology more closely, and to have all the settings described in more detailed.
- Implemented CLI commands for testing, importing users, and pruning users.

**Note to reviewer:**

Please pay special attention to changes in the core classes. At least in case of auto-login it is impossible to test it against any other module (LDAP authentication module is one of its kind in the project atm). Code around auto-login was a bit funky, so I tried to make it less complicated, and I _think_ I got it right.