### PR TITLE
Fixed permission check for editing project VCS integration settings (issue #2767)

### DIFF
--- a/modules/vcs_integration/controllers/Main.php
+++ b/modules/vcs_integration/controllers/Main.php
@@ -662,7 +662,9 @@
         {
             $this->forward403unless($request->isPost());
 
-            if ($this->access_level == framework\Settings::ACCESS_FULL)
+            $project = Project::getB2DBTable()->selectById($request['project_id']);
+
+            if ($this->getUser()->canEditProjectDetails($project))
             {
                 $project_id = $request['project_id'];
 


### PR DESCRIPTION
- Do not use $this->access_level sicne it does not seem to be set anywhere for
  controller.
- Perform check via User::canEditProjectDetails method of requesting user.