### PR TITLE
Allow HTTP basic auth for API requests.

### DIFF
--- a/core/framework/Action.php
+++ b/core/framework/Action.php
@@ -28,6 +28,7 @@
         const AUTHENTICATION_METHOD_RSS_KEY = 'rss_key';
         const AUTHENTICATION_METHOD_APPLICATION_PASSWORD = 'application_password';
         const AUTHENTICATION_METHOD_ELEVATED = 'elevated';
+        const AUTHENTICATION_METHOD_BASIC = 'basic';
 
         public function getAuthenticationMethodForAction($action)
         {


### PR DESCRIPTION
We're currently creating a JIRA REST API v2 compatible API module for The Bug Genie in order to widen the range of third-party applications that are able to interact with TBG.  

As the JIRA REST API has HTTP basic auth support, we added this authentication method to the TBG core for our API requests.

Would be great to having it integrated in TBG as well, so we don't have to patch it on every update.

PS.: We'll release our module to the public once it's fully functional. ;)