### PR TITLE
Issue View: Move comments, history and commits into tabbed activities

### DIFF
--- a/core/modules/main/templates/_issuelogitem.inc.php
+++ b/core/modules/main/templates/_issuelogitem.inc.php
@@ -1,6 +1,6 @@
 <?php if ($item instanceof \thebuggenie\core\entities\LogItem): ?>
     <li>
-        <span class="date"><?php echo (date('YmdHis', $previous_time) != date('YmdHis', $item->getTime())) ? tbg_formatTime($item->getTime(), 6) : ''; ?></span>&nbsp;
+        <span class="date"><?php echo (date('YmdHis', $previous_time) != date('YmdHis', $item->getTime())) ? tbg_formatTime($item->getTime(), 6) : ''; ?></span>
         <?php
 
             $previous_value = null;

--- a/core/modules/main/templates/viewissue.html.php
+++ b/core/modules/main/templates/viewissue.html.php
@@ -328,45 +328,52 @@
                         </fieldset>
                         <?php include_component('main/issuemaincustomfields', array('issue' => $issue)); ?>
                         <?php \thebuggenie\core\framework\Event::createNew('core', 'viewissue_right_bottom', $issue)->trigger(); ?>
-                        <fieldset class="comments" id="viewissue_comments_container">
-                            <legend class="viewissue_comments_header">
-                                <span><?php echo __('Comments (%count)', array('%count' => '<span id="viewissue_comment_count"></span>')); ?></span>
-                                <div class="dropper_container">
-                                    <?php echo image_tag('icon-mono-settings.png', array('class' => 'dropper')); ?>
-                                    <ul class="more_actions_dropdown dropdown_box popup_box leftie" id="comment_dropdown_options">
-                                        <li><a href="javascript:void(0);" id="comments_show_system_comments_toggle" onclick="$$('#comments_box .system_comment').each(function (elm) { $(elm).toggle(); });"><?php echo __('Toggle system-generated comments'); ?></a></li>
-                                        <li><a href="javascript:void(0);" onclick="TBG.Main.Comment.toggleOrder('<?= \thebuggenie\core\entities\Comment::TYPE_ISSUE; ?>', '<?= $issue->getID(); ?>');"><?php echo __('Sort comments in opposite direction'); ?></a></li>
-                                    </ul>
-                                </div>
-                                <?php echo image_tag('spinning_16.gif', array('style' => 'display: none;', 'id' => 'comments_loading_indicator')); ?>
-                                <?php if ($tbg_user->canPostComments() && ((\thebuggenie\core\framework\Context::isProjectContext() && !\thebuggenie\core\framework\Context::getCurrentProject()->isArchived()) || !\thebuggenie\core\framework\Context::isProjectContext())): ?>
-                                    <ul class="simple_list button_container" id="add_comment_button_container">
-                                        <li id="comment_add_button"><input class="button button-silver first last" type="button" onclick="TBG.Main.Comment.showPost();" value="<?php echo __('Post comment'); ?>"></li>
-                                    </ul>
-                                <?php endif; ?>
-                            </legend>
-                            <div id="viewissue_comments">
-                                <?php include_component('main/comments', array('target_id' => $issue->getID(), 'mentionable_target_type' => 'issue', 'target_type' => \thebuggenie\core\entities\Comment::TYPE_ISSUE, 'show_button' => false, 'comment_count_div' => 'viewissue_comment_count', 'save_changes_checked' => $issue->hasUnsavedChanges(), 'issue' => $issue, 'forward_url' => make_url('viewissue', array('project_key' => $issue->getProject()->getKey(), 'issue_no' => $issue->getFormattedIssueNo()), false))); ?>
+
+                        
+                        <ul id="viewissue_activity">
+                            <li><span><?= __('Activity'); ?></span></li>
+                            <li id="tab_viewissue_comments" class="selected"><a href="javascript:void(0);" onclick="TBG.Main.Helpers.tabSwitcher('tab_viewissue_comments', 'viewissue_activity');"><?= __('Comments (%count)', array('%count' => '<span id="viewissue_comment_count"></span>')); ?></a></li>
+                            <?php \thebuggenie\core\framework\Event::createNew('core', 'viewissue_before_tabs', $issue)->trigger(); ?>
+                            <li id="tab_viewissue_history"><a href="javascript:void(0);" onclick="TBG.Main.Helpers.tabSwitcher('tab_viewissue_history', 'viewissue_activity');"><?= __('History'); ?></a></li>
+                        </ul>
+                        <div id="viewissue_activity_panes">
+                            <div id="tab_viewissue_comments_pane">
+                                <fieldset class="comments" id="viewissue_comments_container">
+                                    <div class="viewissue_comments_header">
+                                        <a href="javascript:void(0);" id="comments_show_system_comments_toggle" onclick="$$('#comments_box .system_comment').each(function (elm) { $(elm).toggle(); });"><?php echo __('Toggle system-generated comments'); ?></a>
+                                        <a href="javascript:void(0);" onclick="TBG.Main.Comment.toggleOrder('<?= \thebuggenie\core\entities\Comment::TYPE_ISSUE; ?>', '<?= $issue->getID(); ?>');"><?php echo __('Sort comments in opposite direction'); ?></a>
+                                        <?php echo image_tag('spinning_16.gif', array('style' => 'display: none;', 'id' => 'comments_loading_indicator')); ?>
+                                        <?php if ($tbg_user->canPostComments() && ((\thebuggenie\core\framework\Context::isProjectContext() && !\thebuggenie\core\framework\Context::getCurrentProject()->isArchived()) || !\thebuggenie\core\framework\Context::isProjectContext())): ?>
+                                            <ul class="simple_list button_container" id="add_comment_button_container">
+                                                <li id="comment_add_button"><input class="button button-silver first last" type="button" onclick="TBG.Main.Comment.showPost();" value="<?php echo __('Post comment'); ?>"></li>
+                                            </ul>
+                                        <?php endif; ?>
+                                    </div>
+                                    <div id="viewissue_comments">
+                                        <?php include_component('main/comments', array('target_id' => $issue->getID(), 'mentionable_target_type' => 'issue', 'target_type' => \thebuggenie\core\entities\Comment::TYPE_ISSUE, 'show_button' => false, 'comment_count_div' => 'viewissue_comment_count', 'save_changes_checked' => $issue->hasUnsavedChanges(), 'issue' => $issue, 'forward_url' => make_url('viewissue', array('project_key' => $issue->getProject()->getKey(), 'issue_no' => $issue->getFormattedIssueNo()), false))); ?>
+                                    </div>
+                                    <script type="text/javascript">
+                                        require(['prototype'], function (prototype) {
+                                            $('viewissue_comment_count').update($('comments_box').select('.comment').size());
+                                        });
+                                    </script>
+                                </fieldset>
                             </div>
-                            <script type="text/javascript">
-                                require(['prototype'], function (prototype) {
-                                    $('viewissue_comment_count').update($('comments_box').select('.comment').size());
-                                });
-                            </script>
-                        </fieldset>
-                        <fieldset class="viewissue_history">
-                            <legend class="viewissue_history_header">
-                                <?php echo __('History'); ?>
-                                <?php echo image_tag('spinning_16.gif', array('style' => 'display: none;', 'id' => 'viewissue_log_loading_indicator')); ?>
-                                <div class="button_container" id="viewissue_history_button_container">
-                                    <input class="button button-silver first last" type="button" onclick="TBG.Issues.showLog('<?php echo make_url('issue_log', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>');" value="<?php echo __('Show issue history'); ?>">
-                                </div>
-                            </legend>
-                            <div id="viewissue_log_items"></div>
-                        </fieldset>
-                        <?php \thebuggenie\core\framework\Event::createNew('core', 'viewissue_before_tabs', $issue)->trigger(); ?>
-                        <div id="viewissue_panes">
                             <?php \thebuggenie\core\framework\Event::createNew('core', 'viewissue_after_tabs', $issue)->trigger(); ?>
+                            <div id="tab_viewissue_history_pane" style="display:none;">
+                                <fieldset class="viewissue_history">
+                                    <div id="viewissue_log_items">
+                                        <ul>
+                                            <?php $previous_time = null; ?>
+                                            <?php foreach (array_reverse($issue->getLogEntries()) as $item): ?>
+                                                <?php if (!$item instanceof \thebuggenie\core\entities\LogItem) continue; ?>
+                                                <?php include_component('main/issuelogitem', compact('item', 'previous_time')); ?>
+                                                <?php $previous_time = $item->getTime(); ?>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    </div>
+                                </fieldset>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/modules/vcs_integration/Vcs_integration.php
+++ b/modules/vcs_integration/Vcs_integration.php
@@ -98,7 +98,8 @@
             framework\Event::listen('core', 'project_sidebar_links', array($this, 'listen_project_links'));
             framework\Event::listen('core', 'breadcrumb_project_links', array($this, 'listen_breadcrumb_links'));
             framework\Event::listen('core', 'get_backdrop_partial', array($this, 'listen_getcommit'));
-            framework\Event::listen('core', 'viewissue_left_after_attachments', array($this, 'listen_viewissue_panel'));
+            framework\Event::listen('core', 'viewissue_before_tabs', array($this, 'listen_viewissue_panel_tab'));
+            framework\Event::listen('core', 'viewissue_after_tabs', array($this, 'listen_viewissue_panel'));
             framework\Event::listen('core', 'config_project_tabs_other', array($this, 'listen_projectconfig_tab'));
             framework\Event::listen('core', 'config_project_panes', array($this, 'listen_projectconfig_panel'));
             framework\Event::listen('core', 'project_header_buttons', array($this, 'listen_projectheader'));
@@ -251,12 +252,21 @@
             }
         }
 
+        public function listen_viewissue_panel_tab(framework\Event $event)
+        {
+            if (framework\Context::getModule('vcs_integration')->getSetting('vcs_mode_' . framework\Context::getCurrentProject()->getID()) == self::MODE_DISABLED)
+                return;
+
+            $links_total_count = IssueLinks::getTable()->countByIssueID($event->getSubject()->getID());
+            include_component('vcs_integration/viewissue_activities_tab', array('count' => $links_total_count));
+        }
+
         public function listen_viewissue_panel(framework\Event $event)
         {
             if (framework\Context::getModule('vcs_integration')->getSetting('vcs_mode_' . framework\Context::getCurrentProject()->getID()) == self::MODE_DISABLED)
                 return;
 
-            $links = IssueLink::getCommitsByIssue($event->getSubject(), 3);
+            $links = IssueLink::getCommitsByIssue($event->getSubject());
             $links_total_count = IssueLinks::getTable()->countByIssueID($event->getSubject()->getID());
             include_component('vcs_integration/viewissue_commits', array('issue' => $event->getSubject(), 'links' => $links, 'links_total_count' => $links_total_count, 'selected_project' => $event->getSubject()->getProject()));
         }

--- a/modules/vcs_integration/templates/_viewissue_activities_tab.inc.php
+++ b/modules/vcs_integration/templates/_viewissue_activities_tab.inc.php
@@ -1,0 +1,1 @@
+                <li id="tab_viewissue_commits"><?php echo javascript_link_tag(__('Commits (%count)', array('%count' => $count)), array('onclick' => "TBG.Main.Helpers.tabSwitcher('tab_viewissue_commits', 'viewissue_activity');")); ?></li>

--- a/modules/vcs_integration/templates/_viewissue_commits.inc.php
+++ b/modules/vcs_integration/templates/_viewissue_commits.inc.php
@@ -1,20 +1,11 @@
-<fieldset id="viewissue_vcs_integration_commits_container">
-    <legend>
-        <?php echo __('Commits (%count)', array('%count' => '<span id="viewissue_vcs_integration_commits_count">'.$links_total_count.'</span>')); ?>
-    </legend>
-    <div id="viewissue_vcs_integration_commits">
-        <?php if (count($links) == 0 || !is_array($links)): ?>
-            <div class="no_items"><?php echo __('There are no code checkins for this issue'); ?></div>
-        <?php else: ?>
-            <?php include_component('vcs_integration/issuecommits', array("projectId" => $selected_project->getID(), "links" => $links)); ?>
-        <?php endif; ?>
-    </div>
-    <?php if ($links_total_count > 3): ?>
-        <div class="commits_next">
-            <input id="commits_offset" value="3" type="hidden">
-            <input id="commits_limit" value="<?php echo $links_total_count; ?>" type="hidden">
-            <?php echo image_tag('spinning_16.gif', array('id' => 'commits_indicator', 'style' => 'display: none; float: left; margin-right: 5px;')); ?>
-            <?php echo javascript_link_tag(__('Show all').image_tag('action_add_small.png', array('style' => 'float: left; margin-right: 5px;')), array('onclick' => "TBG.Project.Commits.viewIssueUpdate('".make_url('vcs_viewissue_more', array('project_key' => $selected_project->getKey(), 'issue_no' => $issue->getIssueNo()))."');", 'id' => 'commits_more_link')); ?>
+<div id="tab_viewissue_commits_pane" style="display:none;">
+    <fieldset id="viewissue_vcs_integration_commits_container">
+        <div id="viewissue_vcs_integration_commits">
+            <?php if (count($links) == 0 || !is_array($links)): ?>
+                <div class="no_items"><?php echo __('There are no code checkins for this issue'); ?></div>
+            <?php else: ?>
+                <?php include_component('vcs_integration/issuecommits', array("projectId" => $selected_project->getID(), "links" => $links)); ?>
+            <?php endif; ?>
         </div>
-    <?php endif; ?>
-</fieldset>
+    </fieldset>
+</div>

--- a/themes/oxygen/css/theme.css
+++ b/themes/oxygen/css/theme.css
@@ -4980,6 +4980,7 @@ a.friend {
     margin: 0;
 }
 
+#viewissue_activity,
 #issue_view fieldset legend {
     border: 0;
     color: #777;
@@ -4991,6 +4992,41 @@ a.friend {
     border-bottom: 1px dotted #CCC;
 }
 
+#viewissue_activity {
+    list-style: none;
+    margin: 0 0 0 5px;
+}
+#viewissue_activity li {
+    list-style: none;
+    display: inline-block;
+    height: auto;
+}
+#viewissue_activity li > a,
+#viewissue_activity li > span {
+    padding: 5px 15px 10px;
+}
+#viewissue_activity li.selected > a {
+    background: #fff;
+    border: 1px dotted #CCC;
+    border-bottom: none;
+}
+#viewissue_activity li > span {
+    padding-left: 0;
+}
+.viewissue_comments_header {
+    line-height: 2em;
+    padding: 5px 0;
+    position: relative;
+}
+.viewissue_comments_header a {
+    margin-right: 15px;
+}
+#issue_main .viewissue_comments_header .button_container {
+    padding-top: 3px;
+}
+#issue_main .viewissue_comments_header .button_container .button {
+    font-size: 1em;
+}
 #issue_view fieldset:first-of-type legend, #issue_details_container fieldset legend {
     padding-top: 5px;
 }
@@ -6861,8 +6897,10 @@ ul.workflow_actions .more_actions_dropdown li:hover {
     margin-left: 5px;
 }
 
-#viewissue_log_items {
+#viewissue_log_items,
+#viewissue_vcs_integration_commits {
     min-height: 36px;
+    margin-top: 40px;
 }
 
 #viewissue_log_items ul {
@@ -6874,15 +6912,24 @@ ul.workflow_actions .more_actions_dropdown li:hover {
 #viewissue_log_items ul li {
     list-style: none;
     margin: 0;
-    padding: 2px 0;
+    padding: 2px 0 0 160px;
+    position: relative;
+}
+
+#viewissue_log_items ul li .date {
+    position: absolute;
+    left: 0;
+    top: 4px;
 }
 
 #viewissue_log_items ul li img {
     margin: 3px 5px -3px 5px;
 }
 
-#viewissue_log_items .fa, .comment_log_items .fa {
-    margin-right: 5px;
+#viewissue_log_items .fa {
+    position: absolute;
+    top: 3px;
+    left: 125px;
     padding: 4px;
     border: 1px solid transparent;
 }


### PR DESCRIPTION
This is a proposed GUI enhancement for The Bug Genie.

One of the issues our developers had with the issue view, was finding the commit history or getting a fast overview of the issue history when the comments list is too long.

So we created a tabbed 'Activities' area right under the issue description and steps to reproduce. This area contains tabs for the comments, commits (when VCS integration is enabled), as well as the issue history.

![selection_080](https://user-images.githubusercontent.com/11737051/27476476-82a86264-583b-11e7-938a-af2b1dfa48a2.png)

We re-used the existing event triggers and the empty tab container within the issueview template (hoping it doesn't interfere with the closed source version).
