### PR TITLE
Fix Nginx X-Accel-Redirect location.

### DIFF
--- a/core/modules/main/controllers/Main.php
+++ b/core/modules/main/controllers/Main.php
@@ -3242,7 +3242,7 @@ class Main extends framework\Action
                 {
                     if ($isFile && \thebuggenie\core\framework\Settings::isUploadsDeliveryUseXsend()) {
                         $this->getResponse()->addHeader('X-Sendfile: ' . framework\Settings::getUploadsLocalpath() . $file->getRealFilename());
-                        $this->getResponse()->addHeader('X-Accel-Redirect: /files/' . $file->getRealFilename());
+                        $this->getResponse()->addHeader('X-Accel-Redirect: ' . framework\Settings::getUploadsLocalpath() . $file->getRealFilename());
 
                         $this->getResponse()->renderHeaders($disableCache);
                     }


### PR DESCRIPTION
Minor fix for X-Accel-Redirect, as it did not work with hard-coded files location in my local test environment.