### PR TITLE
Fix intermediate permission levels won't be added to permissions path.

### DIFF
--- a/core/framework/Context.php
+++ b/core/framework/Context.php
@@ -1727,9 +1727,8 @@ class Context
     protected static function addPermissionsPath($permissions, $category, $parent = [])
     {
         foreach ($permissions as $permission => $details) {
-            if (!array_key_exists('details', $details)) {
-                self::$_available_permission_paths[$category][$permission] = array_reverse(array_values($parent));
-            } else {
+            self::$_available_permission_paths[$category][$permission] = array_reverse(array_values($parent));
+            if (array_key_exists('details', $details)) {
                 $path = $parent;
                 $path[$permission] = $permission;
                 self::addPermissionsPath($details['details'], $category, $path);


### PR DESCRIPTION
Noticed, that intermediate permission levels (such as `caneditissuebasic`) which are children of top level permissions, but do have `details` permissions as well, won't be added to `Context::$_available_permission_paths`. Therefore the permissions check on such permissions will return false, even when the top level permission was set.

This merge request fixes this issue.