### PR TITLE
Issue 2778: Change workflow step and status when issue type changes

### DIFF
--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -3247,7 +3247,16 @@
         {
             $this->_addChangedProperty('_issuetype', $issuetype_id);
             $project = $this->getProject();
-            $workflowStep = $project->getWorkflowScheme()->getWorkflowForIssuetype($issuetype_id)->getFirstStep();
+            $issueType = \thebuggenie\core\entities\Issuetype::getB2DBTable()->selectById($issuetype_id);
+            if (! $issueType instanceof \thebuggenie\core\entities\Issuetype || ! $project instanceof \thebuggenie\core\entities\Project)
+            {
+                return;
+            }
+            $workflowStep = $project->getWorkflowScheme()->getWorkflowForIssuetype($issueType)->getFirstStep();
+            if (! $workflowStep instanceof \thebuggenie\core\entities\WorkflowStep)
+            {
+                return;
+            }
             if ($workflowStep->hasLinkedStatus())
             {
                 $this->_addChangedProperty('_status', $workflowStep->getLinkedStatusID());

--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -3246,6 +3246,13 @@
         public function setIssuetype($issuetype_id)
         {
             $this->_addChangedProperty('_issuetype', $issuetype_id);
+            $project = $this->getProject();
+            $workflowStep = $project->getWorkflowScheme()->getWorkflowForIssuetype($issuetype_id)->getFirstStep();
+            if ($workflowStep->hasLinkedStatus())
+            {
+                $this->_addChangedProperty('_status', $workflowStep->getLinkedStatusID());
+            }
+            $this->_addChangedProperty('_workflow_step_id', $workflowStep->getID());
         }
 
         /**


### PR DESCRIPTION
When changing issue types, the issue remains in the old issue type's workflow scheme. This fix also alters the issue's current workflow step to the new issue type's first workflow step, when the issue type changes.

In the current TBG dev version, this pull request depends on pull request #502, as issue types can't be changed otherwise.