### PR TITLE
Prevent from further status or workflow changes

### DIFF
--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -2677,6 +2677,10 @@
          */
         public function setStatus($status_id)
         {
+            if ($this->_isPropertyChanged('_issuetype'))
+            {
+                throw new \Exception(\thebuggenie\core\framework\Context::getI18n()->__("You can't change the status after changing the issue type. Please save your changes first."));
+            }
             $this->_addChangedProperty('_status', $status_id);
         }
 

--- a/public/js/thebuggenie/tbg.js
+++ b/public/js/thebuggenie/tbg.js
@@ -5862,6 +5862,10 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
                 }
 
                 $(field + '_field').addClassName('issue_detail_changed');
+                if (field == 'issuetype') {
+                    jQuery("#workflow_actions input[type='submit'], #workflow_actions input[type='button']").prop("disabled", true);
+                    jQuery("#workflow_actions a").off('click');
+                }
             }
 
             if ($('comment_save_changes'))
@@ -5879,6 +5883,10 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
                     $('viewissue_unsaved').hide();
                     if ($('comment_save_changes'))
                         $('comment_save_changes').checked = false;
+                }
+                if (field == 'issuetype') {
+                    jQuery("#workflow_actions input[type='submit'], #workflow_actions input[type='button']").prop("disabled", false);
+                    jQuery("#workflow_actions a").on('click');
                 }
             }
         }


### PR DESCRIPTION
… when new issue type is not saved.

Refined the issue type change. Disabled workflow transition buttons and prevented from status change after the issue type has been changed (but not saved).

Just to make sure the status and workflow step won't be messed up when the user changes all of 'em at once.