### PR TITLE
Issue #2783: Do not create a non-existing user through password reset page

### DIFF
--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -380,10 +380,22 @@
             return self::getB2DBTable()->getByUsername($username);
         }
 
-        public static function getByEmail($email)
+        /**
+         * Retrieve a user by its email address.
+         *
+         * @param string $email
+         *   Email address of the user.
+         * @param bool $createNew
+         *   Whether to create the user if it does not exist.
+         *   Defaults to `true`.
+         * @return \thebuggenie\core\entities\User|null
+         *   User instance or null, if the user was not found.
+         */
+        public static function getByEmail($email, $createNew = true)
         {
             $user = self::getB2DBTable()->getByEmail($email);
-            if (!$user instanceof User && !framework\Settings::isUsingExternalAuthenticationBackend())
+
+            if (!$user instanceof User && $createNew && !framework\Settings::isUsingExternalAuthenticationBackend())
             {
                 $user = new User();
                 $user->setPassword(self::createPassword());

--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -381,7 +381,7 @@
         }
 
         /**
-         * Retrieve a user by its email address.
+         * Retrieve a user by its email address
          *
          * @param string $email
          *   Email address of the user.

--- a/modules/mailing/controllers/Main.php
+++ b/modules/mailing/controllers/Main.php
@@ -52,7 +52,7 @@
                 }
                 else
                 {
-                    throw new \Exception($i18n->__('Please enter a username or email address.'));
+                    throw new \Exception($i18n->__('Please enter an username or email address.'));
                 }
             }
             catch (\Exception $e)

--- a/modules/mailing/controllers/Main.php
+++ b/modules/mailing/controllers/Main.php
@@ -27,7 +27,7 @@
                     $user = \thebuggenie\core\entities\User::getByUsername($username_or_email);
                     if (!$user instanceof \thebuggenie\core\entities\User)
                     {
-                        $user = \thebuggenie\core\entities\User::getByEmail($username_or_email);
+                        $user = \thebuggenie\core\entities\User::getByEmail($username_or_email, false);
                     }
                     if ($user instanceof \thebuggenie\core\entities\User)
                     {
@@ -36,26 +36,23 @@
                             if ($user->getEmail())
                             {
                                 framework\Context::getModule('mailing')->sendForgottenPasswordEmail($user);
-                                return $this->renderJSON(array('message' => $i18n->__('Please use the link in the email you received')));
                             }
-                            else
-                            {
-                                throw new \Exception($i18n->__('Cannot find an email address for this user'));
-                            }
+                            return $this->renderJSON(array('message' => $i18n->__("If you are a registered user, we sent you an email. Please use the link in the email you received to reset your password.")));
                         }
                         else
                         {
-                            throw new \Exception($i18n->__('Forbidden for this username, please contact your administrator'));
+                            throw new \Exception($i18n->__('Your user account has been disabled. Please contact your administrator.'));
                         }
                     }
                     else
                     {
-                        throw new \Exception($i18n->__('This username does not exist'));
+                        // Protect from user name/email guessing in not telling whether the username/email address exists.
+                        return $this->renderJSON(array('message' => $i18n->__("If you are a registered user, we sent you an email. Please use the link in the email you received to reset your password.")));
                     }
                 }
                 else
                 {
-                    throw new \Exception($i18n->__('Please enter an username'));
+                    throw new \Exception($i18n->__('Please enter a username or email address.'));
                 }
             }
             catch (\Exception $e)


### PR DESCRIPTION
This pull request fixes issue #2783. Users will be created if they use a non-existing email address within the password reset dialog.