### PR TITLE
Do not cache permissions during installation

### DIFF
--- a/core/framework/Context.php
+++ b/core/framework/Context.php
@@ -2560,7 +2560,13 @@ class Context
 
             self::setupI18n();
 
-            self::_cacheAvailablePermissions();
+            // Available permissions cannot be cached during
+            // installation because the scope is not set-up at that
+            // point. Permissions also must be cached at this point,
+            // and not together with self::initializeUser since i18n
+            // system must be initialised beforehand.
+            if (!self::isInstallmode())
+                self::_cacheAvailablePermissions();
 
             if (self::$_redirect_login == 'login') {
 


### PR DESCRIPTION
This pull request addresses the following issues:

- During installation an error will occur because when permissions are being cached a call is being made to get the scope ID, which at that point does not exist yet. Therefore, permissions should be cached only when TBG is not in install mode.