### PR TITLE
Improved handling of colour output in CLI:

### DIFF
--- a/core/modules/main/cli/Help.php
+++ b/core/modules/main/cli/Help.php
@@ -113,6 +113,9 @@
             }
             else
             {
+                $this->cliEcho("\n");
+                $this->cliEcho("To suppress colour output (useful for automation scripts), set environment variable TBG_NO_COLOR to 1.\n");
+                $this->cliEcho("\n");
                 $this->cliEcho("Below is a list of available commands:\n");
                 $this->cliEcho("Type ");
                 $this->cliEcho(\thebuggenie\core\framework\cli\Command::getCommandLineName() . ' ', 'white', 'bold');


### PR DESCRIPTION
- Do not use colour when output goes to non-interactive
  terminal (piping).
- Added ability to suppress colour output by setting an environment
  variable (useful for automation).