### PR TITLE
Correction for LogItem removal of XSS vulnerability. For example <scr…

### DIFF
--- a/core/entities/LogItem.php
+++ b/core/entities/LogItem.php
@@ -119,7 +119,7 @@
 
         public function getPreviousValue()
         {
-            return $this->_previous_value;
+            return htmlspecialchars($this->_previous_value);
         }
 
         public function setPreviousValue($previous_value)
@@ -129,7 +129,7 @@
 
         public function getCurrentValue()
         {
-            return $this->_current_value;
+            return htmlspecialchars($this->_current_value);
         }
 
         public function setCurrentValue($current_value)


### PR DESCRIPTION
…ipt>alert(document.cookie);</script> set into an issue's title will make the show log execute that code literally, instead of escaping the code when required via ajax. This was donde directly on the LogItem since these values are the input values changed by the end user.