### PR TITLE
Refactor and clean-up of code related to finding related and duplicate issues

### DIFF
--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -4001,22 +4001,6 @@
         }
 
         /**
-         * Helper method that returns state as text. This method
-         * should only be used for displaying result to the end user.
-         *
-         * @return State of issue (OPEN/CLOSED) as text.
-         */
-        public function getStateAsText()
-        {
-            if ($this->isOpen())
-            {
-                return "OPEN";
-            }
-
-            return "CLOSED";
-        }
-
-        /**
          * Whether or not the issue is closed
          *
          * @see getState()

--- a/core/modules/main/configuration/routes.yml
+++ b/core/modules/main/configuration/routes.yml
@@ -465,8 +465,8 @@ move_issue:
     parameters: [ ]
     csrf_enabled: false
 
-viewissue_find_issue:
-    route: /:project_key/findrelatedissues/:issue_id/:type
+viewissue_find_related_issues:
+    route: /:project_key/find_issues/:issue_id/related
     module: main
     action: findRelatedIssues
     parameters:
@@ -486,6 +486,14 @@ viewissue_remove_related_issue:
     module: main
     action: removeRelatedIssue
     parameters: [ ]
+    csrf_enabled: false
+
+viewissue_find_duplicated_issue:
+    route: /:project_key/find_issues/:issue_id/duplicated
+    module: main
+    action: findDuplicatedIssue
+    parameters:
+      format: json
     csrf_enabled: false
 
 viewissue_remove_duplicated_issue:

--- a/core/modules/main/configuration/routes.yml
+++ b/core/modules/main/configuration/routes.yml
@@ -466,9 +466,9 @@ move_issue:
     csrf_enabled: false
 
 viewissue_find_issue:
-    route: /:project_key/findissues/:issue_id/:type
+    route: /:project_key/findrelatedissues/:issue_id/:type
     module: main
-    action: findIssue
+    action: findRelatedIssues
     parameters:
       format: json
     csrf_enabled: false

--- a/core/modules/main/templates/_findduplicateissues.inc.php
+++ b/core/modules/main/templates/_findduplicateissues.inc.php
@@ -1,12 +1,11 @@
-<?php if ($count > 0): ?>
-    <div class="header_div" style="margin-bottom: 5px;"><?php echo __('The following issues matched your search'); ?>:</div>
+<?php if ($matched_issues): ?>
+    <div class="header_div" style="margin-bottom: 5px;"><?= __('The following issues matched your search'); ?>:</div>
     <input type="hidden" name="issue_action" value="duplicate">
     <select name="duplicate_issue_id" style="width: 100%">
-        <?php foreach ($issues as $anIssue): ?>
-            <?php if (isset($issue) && $issue instanceof \thebuggenie\core\entities\Issue && $anIssue->getID() == $issue->getID()): continue; endif; ?>
-            <option value="<?php echo $anIssue->getID(); ?>">[<?php if ($anIssue->getState() == \thebuggenie\core\entities\Issue::STATE_OPEN): echo __('OPEN'); else: echo __('CLOSED'); endif; ?>] <?php echo $anIssue->getFormattedTitle(); ?></option>
+        <?php foreach ($matched_issues as $matched_issue): ?>
+            <option value="<?= $matched_issue->getID(); ?>">[<?= $matched_issue->getStateAsText(); ?>] <?= $matched_issue->getFormattedTitle(); ?></option>
         <?php endforeach; ?>
     </select>
 <?php else: ?>
-    <span class="faded_out"><?php echo __('No issues matched your search. Please try again with different search terms.'); ?></span>
+    <span class="faded_out"><?= __('No issues matched your search. Please try again with different search terms.'); ?></span>
 <?php endif; ?>

--- a/core/modules/main/templates/_findduplicateissues.inc.php
+++ b/core/modules/main/templates/_findduplicateissues.inc.php
@@ -3,7 +3,7 @@
     <input type="hidden" name="issue_action" value="duplicate">
     <select name="duplicate_issue_id" style="width: 100%">
         <?php foreach ($matched_issues as $matched_issue): ?>
-            <option value="<?= $matched_issue->getID(); ?>">[<?= $matched_issue->getStateAsText(); ?>] <?= $matched_issue->getFormattedTitle(); ?></option>
+            <option value="<?= $matched_issue->getID(); ?>">[<?= ($matched_issue->isOpen()) ? __('Open') : __('Closed'); ?>] <?= $matched_issue->getFormattedTitle(); ?></option>
         <?php endforeach; ?>
     </select>
 <?php else: ?>

--- a/core/modules/main/templates/_findrelatedissues.inc.php
+++ b/core/modules/main/templates/_findrelatedissues.inc.php
@@ -18,7 +18,7 @@
                         <tr>
                             <td style="width: 20px;"><input type="checkbox" value="<?= $matched_issue->getID(); ?>" name="relate_issues[<?= $matched_issue->getID(); ?>]" id="relate_issue_<?= $matched_issue->getID(); ?>"></td>
                             <td class="issue_title">
-                                <label for="relate_issue_<?= $matched_issue->getID(); ?>" style="font-weight: normal;">[<?= __($matched_issue->getStateAsText()); ?>] <?= $matched_issue->getFormattedTitle(); ?></label>
+                                <label for="relate_issue_<?= $matched_issue->getID(); ?>" style="font-weight: normal;">[<?= ($matched_issue->isOpen()) ? __('Open') : __('Closed'); ?>] <?= $matched_issue->getFormattedTitle(); ?></label>
                             </td>
                         </tr>
                     <?php endforeach; ?>

--- a/core/modules/main/templates/_findrelatedissues.inc.php
+++ b/core/modules/main/templates/_findrelatedissues.inc.php
@@ -1,29 +1,41 @@
-<?php if ($count > 0): ?>
-    <div class="header_div"><?php echo __('The following issues matched your search'); ?>:</div>
-    <span class="faded_out"><?php echo __('Either use the checkboxes and press the "%relate_these_issues"-button below or click any issues in the list, and select an action.', array('%relate_these_issues' => __('Relate these issues'))); ?></span>
-    <form id="viewissue_relate_issues_form" action="<?php echo make_url('viewissue_relate_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>" method="post" accept-charset="<?php echo \thebuggenie\core\framework\Settings::getCharset(); ?>" onsubmit="TBG.Issues.relate('<?php echo make_url('viewissue_relate_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>');return false;">
+<?php if ($grouped_issues): ?>
+
+    <div class="header_div"><?= __('The following issues matched your search'); ?>:</div>
+    <span class="faded_out"><?= __('Either use the checkboxes and press the "%relate_these_issues"-button below or click any issues in the list, and select an action.', array('%relate_these_issues' => __('Relate these issues'))); ?></span>
+    <form id="viewissue_relate_issues_form" action="<?= make_url('viewissue_relate_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>" method="post" accept-charset="<?= \thebuggenie\core\framework\Settings::getCharset(); ?>" onsubmit="TBG.Issues.relate('<?= make_url('viewissue_relate_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>');return false;">
+
         <div style="height: 400px; overflow: auto">
-        <table style="width: auto; border: 0;" cellpadding="0" cellspacing="0">
-            <?php foreach ($issues as $aissue): ?>
-                <?php if ($aissue->getID() == $issue->getID()): continue; endif; ?>
-                <tr>
-                    <td style="width: 20px;"><input type="checkbox" value="<?php echo $aissue->getID(); ?>" name="relate_issues[<?php echo $aissue->getID(); ?>]" id="relate_issue_<?php echo $aissue->getID(); ?>"></td>
-                    <td class="issue_title">
-                        <label for="relate_issue_<?php echo $aissue->getID(); ?>" style="font-weight: normal;">[<?php if ($aissue->getState() == \thebuggenie\core\entities\Issue::STATE_OPEN): echo __('OPEN'); else: echo __('CLOSED'); endif; ?>] <?php echo $aissue->getFormattedTitle(); ?></label>
-                    </td>
-                </tr>
+            <?php foreach($grouped_issues as $project => $matched_issues): ?>
+                <?php if ($issue->getProject()->getName() == $project): ?>
+                    <div class="header_div smaller"><?= __('Current project') ?></div>
+                <?php else: ?>
+                    <div class="header_div smaller"><?= $project ?></div>
+                <?php endif; ?>
+
+                <table style="width: auto; border: 0;" cellpadding="0" cellspacing="0">
+
+                    <?php foreach($matched_issues as $matched_issue): ?>
+                        <tr>
+                            <td style="width: 20px;"><input type="checkbox" value="<?= $matched_issue->getID(); ?>" name="relate_issues[<?= $matched_issue->getID(); ?>]" id="relate_issue_<?= $matched_issue->getID(); ?>"></td>
+                            <td class="issue_title">
+                                <label for="relate_issue_<?= $matched_issue->getID(); ?>" style="font-weight: normal;">[<?= __($matched_issue->getStateAsText()); ?>] <?= $matched_issue->getFormattedTitle(); ?></label>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+
+                </table>
             <?php endforeach; ?>
-        </table>
         </div>
-        <p><label><input type="radio" id="relate_issue_with_selected" name="relate_action" checked="checked" value="relate_children"> <?php echo __('Add checked issues as children'); ?></label></p>
-        <p><label><input type="radio" id="relate_issue_with_selected" name="relate_action" value="relate_parent"> <?php echo __('Set selected issue as parent'); ?></label></p>
+
+        <p><label><input type="radio" id="relate_issue_with_selected" name="relate_action" checked="checked" value="relate_children"> <?= __('Add checked issues as children'); ?></label></p>
+        <p><label><input type="radio" id="relate_issue_with_selected" name="relate_action" value="relate_parent"> <?= __('Set selected issue as parent'); ?></label></p>
         <br>
         <div style="text-align: right; border-top: 1px dotted #CCC; padding-top: 5px;">
-            <input type="submit" value="<?php echo __('Relate these issues'); ?>">
-            <?php echo image_tag('spinning_20.gif', array('id' => 'relate_issues_indicator', 'style' => 'display: none;')); ?><br>
+            <input type="submit" value="<?= __('Relate these issues'); ?>">
+            <?= image_tag('spinning_20.gif', array('id' => 'relate_issues_indicator', 'style' => 'display: none;')); ?><br>
         </div>
     </form>
-    
+
 <?php else: ?>
-    <span class="faded_out"><?php echo __('No issues matched your search. Please try again with different search terms.'); ?></span>
+    <span class="faded_out"><?= __('No issues matched your search. Please try again with different search terms.'); ?></span>
 <?php endif; ?>

--- a/core/modules/main/templates/_relateissue.inc.php
+++ b/core/modules/main/templates/_relateissue.inc.php
@@ -2,13 +2,13 @@
     <div class="backdrop_detail_header"><?php echo __('Find related issues'); ?></div>
     <div id="backdrop_detail_content" class="backdrop_detail_content">
         <?php echo __('Please enter some details to search for, and then select the matching issues to relate them'); ?>
-        <form id="viewissue_find_issue_form" action="<?php echo make_url('viewissue_find_issue', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID(), 'type' => 'related')); ?>" method="post" accept-charset="<?php echo \thebuggenie\core\framework\Settings::getCharset(); ?>" onsubmit="TBG.Issues.findRelated('<?php echo make_url('viewissue_find_issue', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID(), 'type' => 'related')); ?>');return false;">
+        <form id="viewissue_find_related_issues_form" action="<?php echo make_url('viewissue_find_related_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>" method="post" accept-charset="<?php echo \thebuggenie\core\framework\Settings::getCharset(); ?>" onsubmit="TBG.Issues.findRelated('<?php echo make_url('viewissue_find_related_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>');return false;">
             <div>
-                <label for="viewissue_find_issue_input"><?php echo __('Find issue(s)'); ?>&nbsp;</label>
-                <input type="text" name="searchfor" id="viewissue_find_issue_input">
+                <label for="viewissue_find_related_issues_input"><?php echo __('Find issue(s)'); ?>&nbsp;</label>
+                <input type="text" name="searchfor" id="viewissue_find_related_issues_input">
                 <input type="submit" value="<?php echo __('Find'); ?>" style="margin-top: -3px;">
                 <?php echo __('%find or %cancel', array('%find' => '', '%cancel' => '<a href="javascript:void(0);" onclick="TBG.Main.Helpers.Backdrop.reset();">' . __('cancel') . '</a>')); ?>
-                <?php echo image_tag('spinning_20.gif', array('id' => 'find_issue_indicator', 'style' => 'display: none;')); ?><br>
+                <?php echo image_tag('spinning_20.gif', array('id' => 'viewissue_find_related_issues_indicator', 'style' => 'display: none;')); ?><br>
             </div>
         </form>
         <div id="viewissue_relation_results"></div>

--- a/core/modules/main/templates/_relateissue.inc.php
+++ b/core/modules/main/templates/_relateissue.inc.php
@@ -2,13 +2,13 @@
     <div class="backdrop_detail_header"><?php echo __('Find related issues'); ?></div>
     <div id="backdrop_detail_content" class="backdrop_detail_content">
         <?php echo __('Please enter some details to search for, and then select the matching issues to relate them'); ?>
-        <form id="viewissue_find_related_issues_form" action="<?php echo make_url('viewissue_find_related_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>" method="post" accept-charset="<?php echo \thebuggenie\core\framework\Settings::getCharset(); ?>" onsubmit="TBG.Issues.findRelated('<?php echo make_url('viewissue_find_related_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>');return false;">
+        <form id="viewissue_find_issue_form" action="<?php echo make_url('viewissue_find_related_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>" method="post" accept-charset="<?php echo \thebuggenie\core\framework\Settings::getCharset(); ?>" onsubmit="TBG.Issues.findRelated('<?php echo make_url('viewissue_find_related_issues', array('project_key' => $issue->getProject()->getKey(), 'issue_id' => $issue->getID())); ?>');return false;">
             <div>
-                <label for="viewissue_find_related_issues_input"><?php echo __('Find issue(s)'); ?>&nbsp;</label>
-                <input type="text" name="searchfor" id="viewissue_find_related_issues_input">
+                <label for="viewissue_find_issue_input"><?php echo __('Find issue(s)'); ?>&nbsp;</label>
+                <input type="text" name="searchfor" id="viewissue_find_issue_input">
                 <input type="submit" value="<?php echo __('Find'); ?>" style="margin-top: -3px;">
                 <?php echo __('%find or %cancel', array('%find' => '', '%cancel' => '<a href="javascript:void(0);" onclick="TBG.Main.Helpers.Backdrop.reset();">' . __('cancel') . '</a>')); ?>
-                <?php echo image_tag('spinning_20.gif', array('id' => 'viewissue_find_related_issues_indicator', 'style' => 'display: none;')); ?><br>
+                <?php echo image_tag('spinning_20.gif', array('id' => 'viewissue_find_issue_indicator', 'style' => 'display: none;')); ?><br>
             </div>
         </form>
         <div id="viewissue_relation_results"></div>

--- a/core/modules/main/templates/_updateissueproperties.inc.php
+++ b/core/modules/main/templates/_updateissueproperties.inc.php
@@ -46,16 +46,16 @@
                 <?php endif; ?>
                 <?php if (($issue instanceof \thebuggenie\core\entities\Issue && ($issue->isUpdateable() && !$issue->isDuplicate()) || isset($issues)) && $transition->hasAction(\thebuggenie\core\entities\WorkflowTransitionAction::ACTION_SET_DUPLICATE)): ?>
                     <li class="duplicate_search">
-                        <label for="viewissue_find_issue_<?php echo $transition->getID(); ?>_input"><?php echo __('Find issue(s)'); ?>&nbsp;</label>
-                        <input type="text" name="searchfor" id="viewissue_find_issue_<?php echo $transition->getID(); ?>_input">
-                        <input class="button button-blue" type="button" onclick="TBG.Issues.findDuplicate($('duplicate_finder_transition_<?php echo $transition->getID(); ?>').getValue(), <?php echo $transition->getID(); ?>);return false;" value="<?php echo __('Find'); ?>" id="viewissue_find_issue_<?php echo $transition->getID(); ?>_submit">
-                        <?php echo image_tag('spinning_20.gif', array('id' => 'find_issue_'.$transition->getID().'_indicator', 'style' => 'display: none;')); ?><br>
+                        <label for="viewissue_find_duplicated_issue_<?php echo $transition->getID(); ?>_input"><?php echo __('Find issue(s)'); ?>&nbsp;</label>
+                        <input type="text" name="searchfor" id="viewissue_find_duplicated_issue_<?php echo $transition->getID(); ?>_input">
+                        <input class="button button-blue" type="button" onclick="TBG.Issues.findDuplicate($('duplicate_finder_transition_<?php echo $transition->getID(); ?>').getValue(), <?php echo $transition->getID(); ?>);return false;" value="<?php echo __('Find'); ?>" id="viewissue_find_duplicated_issue_<?php echo $transition->getID(); ?>_submit">
+                        <?php echo image_tag('spinning_20.gif', array('id' => 'viewissue_find_duplicated_issue_'.$transition->getID().'_indicator', 'style' => 'display: none;')); ?><br>
                         <div id="viewissue_<?php echo $transition->getID(); ?>_duplicate_results"></div>
-                        <input type="hidden" name="transition_duplicate_ulr[<?php echo $transition->getID(); ?>]" id="duplicate_finder_transition_<?php echo $transition->getID(); ?>" value="<?php echo ($issue instanceof \thebuggenie\core\entities\Issue) ? make_url('viewissue_find_issue', array('project_key' => $project->getKey(), 'issue_id' => $issue->getID(), 'type' => 'duplicate')) : make_url('viewissue_find_issue', array('project_key' => $project->getKey(), 'type' => 'duplicate')); ?>">
+                        <input type="hidden" name="transition_duplicate_ulr[<?php echo $transition->getID(); ?>]" id="duplicate_finder_transition_<?php echo $transition->getID(); ?>" value="<?php echo make_url('viewissue_find_duplicated_issue', array('project_key' => $project->getKey(), 'issue_id' => $issue->getID())); ?>">
                         <?php if (!$issue instanceof \thebuggenie\core\entities\Issue): ?>
                         <script type="text/javascript">
                             var transition_id = <?php echo $transition->getID(); ?>;
-                            $('viewissue_find_issue_' + transition_id + '_input').observe('keypress', function(event) {
+                            $('viewissue_find_duplicated_issue_' + transition_id + '_input').observe('keypress', function(event) {
                                 if (event.keyCode == Event.KEY_RETURN) {
                                     TBG.Issues.findDuplicate($('duplicate_finder_transition_' + transition_id).getValue(), transition_id);
                                     event.stop();

--- a/core/modules/main/templates/_updateissueproperties.inc.php
+++ b/core/modules/main/templates/_updateissueproperties.inc.php
@@ -46,16 +46,16 @@
                 <?php endif; ?>
                 <?php if (($issue instanceof \thebuggenie\core\entities\Issue && ($issue->isUpdateable() && !$issue->isDuplicate()) || isset($issues)) && $transition->hasAction(\thebuggenie\core\entities\WorkflowTransitionAction::ACTION_SET_DUPLICATE)): ?>
                     <li class="duplicate_search">
-                        <label for="viewissue_find_duplicated_issue_<?php echo $transition->getID(); ?>_input"><?php echo __('Find issue(s)'); ?>&nbsp;</label>
-                        <input type="text" name="searchfor" id="viewissue_find_duplicated_issue_<?php echo $transition->getID(); ?>_input">
-                        <input class="button button-blue" type="button" onclick="TBG.Issues.findDuplicate($('duplicate_finder_transition_<?php echo $transition->getID(); ?>').getValue(), <?php echo $transition->getID(); ?>);return false;" value="<?php echo __('Find'); ?>" id="viewissue_find_duplicated_issue_<?php echo $transition->getID(); ?>_submit">
-                        <?php echo image_tag('spinning_20.gif', array('id' => 'viewissue_find_duplicated_issue_'.$transition->getID().'_indicator', 'style' => 'display: none;')); ?><br>
+                        <label for="viewissue_find_issue_<?php echo $transition->getID(); ?>_input"><?php echo __('Find issue(s)'); ?>&nbsp;</label>
+                        <input type="text" name="searchfor" id="viewissue_find_issue_<?php echo $transition->getID(); ?>_input">
+                        <input class="button button-blue" type="button" onclick="TBG.Issues.findDuplicate($('duplicate_finder_transition_<?php echo $transition->getID(); ?>').getValue(), <?php echo $transition->getID(); ?>);return false;" value="<?php echo __('Find'); ?>" id="viewissue_find_issue_<?php echo $transition->getID(); ?>_submit">
+                        <?php echo image_tag('spinning_20.gif', array('id' => 'viewissue_find_issue_'.$transition->getID().'_indicator', 'style' => 'display: none;')); ?><br>
                         <div id="viewissue_<?php echo $transition->getID(); ?>_duplicate_results"></div>
                         <input type="hidden" name="transition_duplicate_ulr[<?php echo $transition->getID(); ?>]" id="duplicate_finder_transition_<?php echo $transition->getID(); ?>" value="<?php echo make_url('viewissue_find_duplicated_issue', array('project_key' => $project->getKey(), 'issue_id' => $issue->getID())); ?>">
                         <?php if (!$issue instanceof \thebuggenie\core\entities\Issue): ?>
                         <script type="text/javascript">
                             var transition_id = <?php echo $transition->getID(); ?>;
-                            $('viewissue_find_duplicated_issue_' + transition_id + '_input').observe('keypress', function(event) {
+                            $('viewissue_find_issue_' + transition_id + '_input').observe('keypress', function(event) {
                                 if (event.keyCode == Event.KEY_RETURN) {
                                     TBG.Issues.findDuplicate($('duplicate_finder_transition_' + transition_id).getValue(), transition_id);
                                     event.stop();

--- a/core/modules/main/templates/http400.json.php
+++ b/core/modules/main/templates/http400.json.php
@@ -1,0 +1,1 @@
+<?= (isset($message)) ? json_encode(array('error' => $message)) : json_encode(array('error' => __("You have sent an invalid request."))); ?>

--- a/core/modules/main/templates/notfound.json.php
+++ b/core/modules/main/templates/notfound.json.php
@@ -1,0 +1,1 @@
+<?= (isset($message)) ? json_encode(array('error' => $message)) : json_encode(array('error' => __("This location doesn't exist, has been deleted or you don't have permission to see it"))); ?>

--- a/public/js/thebuggenie/tbg.js
+++ b/public/js/thebuggenie/tbg.js
@@ -5181,7 +5181,7 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
             $('workflow_transition_fullpage').appear({duration: 0.2});
             workflow_div.appear({duration: 0.2, afterFinish: function () {
                 if ($('duplicate_finder_transition_' + transition_id)) {
-                    $('viewissue_find_duplicated_issue_' + transition_id + '_input').observe('keypress', function (event) {
+                    $('viewissue_find_issue_' + transition_id + '_input').observe('keypress', function (event) {
                         if (event.keyCode == Event.KEY_RETURN) {
                             TBG.Issues.findDuplicate($('duplicate_finder_transition_' + transition_id).getValue(), transition_id);
                             event.stop();
@@ -5239,8 +5239,8 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
 
         TBG.Issues.findRelated = function (url) {
             TBG.Main.Helpers.ajax(url, {
-                form: 'viewissue_find_related_issues_form',
-                loading: {indicator: 'viewissue_find_related_issues_indicator'},
+                form: 'viewissue_find_issue_form',
+                loading: {indicator: 'viewissue_find_issue_indicator'},
                 success: {update: 'viewissue_relation_results'}
             });
             return false;
@@ -5248,8 +5248,8 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
 
         TBG.Issues.findDuplicate = function (url, transition_id) {
             TBG.Main.Helpers.ajax(url, {
-                additional_params: 'searchfor=' + $('viewissue_find_duplicated_issue_' + transition_id + '_input').getValue(),
-                loading: {indicator: 'viewissue_find_duplicated_issue_' + transition_id + '_indicator'},
+                additional_params: 'searchfor=' + $('viewissue_find_issue_' + transition_id + '_input').getValue(),
+                loading: {indicator: 'viewissue_find_issue_' + transition_id + '_indicator'},
                 success: {update: 'viewissue_' + transition_id + '_duplicate_results'}
             });
         };

--- a/public/js/thebuggenie/tbg.js
+++ b/public/js/thebuggenie/tbg.js
@@ -5181,7 +5181,7 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
             $('workflow_transition_fullpage').appear({duration: 0.2});
             workflow_div.appear({duration: 0.2, afterFinish: function () {
                 if ($('duplicate_finder_transition_' + transition_id)) {
-                    $('viewissue_find_issue_' + transition_id + '_input').observe('keypress', function (event) {
+                    $('viewissue_find_duplicated_issue_' + transition_id + '_input').observe('keypress', function (event) {
                         if (event.keyCode == Event.KEY_RETURN) {
                             TBG.Issues.findDuplicate($('duplicate_finder_transition_' + transition_id).getValue(), transition_id);
                             event.stop();
@@ -5239,8 +5239,8 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
 
         TBG.Issues.findRelated = function (url) {
             TBG.Main.Helpers.ajax(url, {
-                form: 'viewissue_find_issue_form',
-                loading: {indicator: 'find_issue_indicator'},
+                form: 'viewissue_find_related_issues_form',
+                loading: {indicator: 'viewissue_find_related_issues_indicator'},
                 success: {update: 'viewissue_relation_results'}
             });
             return false;
@@ -5248,8 +5248,8 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
 
         TBG.Issues.findDuplicate = function (url, transition_id) {
             TBG.Main.Helpers.ajax(url, {
-                additional_params: 'searchfor=' + $('viewissue_find_issue_' + transition_id + '_input').getValue(),
-                loading: {indicator: 'find_issue_' + transition_id + '_indicator'},
+                additional_params: 'searchfor=' + $('viewissue_find_duplicated_issue_' + transition_id + '_input').getValue(),
+                loading: {indicator: 'viewissue_find_duplicated_issue_' + transition_id + '_indicator'},
                 success: {update: 'viewissue_' + transition_id + '_duplicate_results'}
             });
         };

--- a/themes/oxygen/css/theme.css
+++ b/themes/oxygen/css/theme.css
@@ -5645,7 +5645,7 @@ ul.workflow_actions li:hover {
     box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
 }
 
-#viewissue_find_issue_input {
+#viewissue_find_related_issues_input {
     width: 350px;
 }
 
@@ -7133,13 +7133,13 @@ ul.workflow_actions .more_actions_dropdown li:hover {
     margin-top: -3px;
 }
 
-#viewissue_find_issue_form div {
+#viewissue_find_related_issues_form div {
     text-align: left;
     font-size: 0.9em;
     margin-top: 10px;
 }
 
-#viewissue_find_issue_form input[type="text"] {
+#viewissue_find_related_issues_form input[type="text"] {
     width: 300px;
 }
 
@@ -16511,7 +16511,7 @@ img[id^='remove_assignee_team_'][id$='_indicator'] {
     padding: 2px 14px;
 }
 
-#viewissue_add_relation_div #find_issue_indicator {
+#viewissue_add_relation_div #viewissue_find_related_issues_indicator {
     position: absolute;
     margin-left: 5px;
 }
@@ -17097,11 +17097,11 @@ div[id^='issue_transition_container_'] .button-group {
     margin-top: -4px;
 }
 
-div[id^='issue_transition_container_'] .duplicate_search input[id^='viewissue_find_issue_'][id$='_input'] {
+div[id^='issue_transition_container_'] .duplicate_search input[id^='viewissue_find_duplicated_issue_'][id$='_input'] {
     width: 566px;
 }
 
-div[id^='issue_transition_container_'] .duplicate_search input[id^='viewissue_find_issue_'][id$='_submit'] {
+div[id^='issue_transition_container_'] .duplicate_search input[id^='viewissue_find_duplicated_issue_'][id$='_submit'] {
     line-height: 18px !important;
     margin-left: -5px;
 }

--- a/themes/oxygen/css/theme.css
+++ b/themes/oxygen/css/theme.css
@@ -7429,6 +7429,10 @@ ul.attached_items {
     box-sizing: border-box;
 }
 
+.duplicate_search select {
+    text-transform: uppercase;
+}
+
 table.issue_affects td {
     padding: 3px;
 }

--- a/themes/oxygen/css/theme.css
+++ b/themes/oxygen/css/theme.css
@@ -5645,7 +5645,7 @@ ul.workflow_actions li:hover {
     box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
 }
 
-#viewissue_find_related_issues_input {
+#viewissue_find_issue_input {
     width: 350px;
 }
 
@@ -7133,13 +7133,13 @@ ul.workflow_actions .more_actions_dropdown li:hover {
     margin-top: -3px;
 }
 
-#viewissue_find_related_issues_form div {
+#viewissue_find_issue_form div {
     text-align: left;
     font-size: 0.9em;
     margin-top: 10px;
 }
 
-#viewissue_find_related_issues_form input[type="text"] {
+#viewissue_find_issue_form input[type="text"] {
     width: 300px;
 }
 
@@ -16511,7 +16511,7 @@ img[id^='remove_assignee_team_'][id$='_indicator'] {
     padding: 2px 14px;
 }
 
-#viewissue_add_relation_div #viewissue_find_related_issues_indicator {
+#viewissue_add_relation_div #viewissue_find_issue_indicator {
     position: absolute;
     margin-left: 5px;
 }
@@ -17097,11 +17097,11 @@ div[id^='issue_transition_container_'] .button-group {
     margin-top: -4px;
 }
 
-div[id^='issue_transition_container_'] .duplicate_search input[id^='viewissue_find_duplicated_issue_'][id$='_input'] {
+div[id^='issue_transition_container_'] .duplicate_search input[id^='viewissue_find_issue_'][id$='_input'] {
     width: 566px;
 }
 
-div[id^='issue_transition_container_'] .duplicate_search input[id^='viewissue_find_duplicated_issue_'][id$='_submit'] {
+div[id^='issue_transition_container_'] .duplicate_search input[id^='viewissue_find_issue_'][id$='_submit'] {
     line-height: 18px !important;
     margin-left: -5px;
 }

--- a/themes/tanuki/css/theme.css
+++ b/themes/tanuki/css/theme.css
@@ -16439,7 +16439,7 @@ img[id^='remove_assignee_team_'][id$='_indicator'] {
     padding: 2px 14px;
 }
 
-#viewissue_add_relation_div #find_issue_indicator {
+#viewissue_add_relation_div #viewissue_find_issue_indicator {
     position: absolute;
     margin-left: 5px;
 }


### PR DESCRIPTION
The purpose of this PR is to clean-up the code responsible for finding the related and duplicate issues, and presenting the user with appropriate choices. This is an initial PR, and some more rigorous verification would be welcome.

The refactor concentrates on:

- Separating views for finding related and duplicate issues since their presentation layers are quite different (have different needs).
- Grouping the possible related issues when presenting them to the user (exact match -> same project -> other projects by alphabetical sorting).
- Refactoring slightly how finding of issues works in order to be able to locate both exact match and free-text search issues at the same time.

Things to pay attention to:

- In addition to standard functionality, possibly paying some attention to how sorting of projects by name is implemented (not sure I picked the correct function, particularly if project names use unicode letters).