### PR TITLE
Fix project tabs on index page

### DIFF
--- a/core/modules/main/templates/_projectlist.inc.php
+++ b/core/modules/main/templates/_projectlist.inc.php
@@ -1,7 +1,6 @@
 <div class="project_overview">
     <div class="tab_menu inset">
         <ul id="projects_list_tabs">
-            <?php /* <li id="tab_starred"><a onclick="TBG.Main.Helpers.tabSwitcher('tab_starred', 'projects_list_tabs', true);" href="javascript:void(0);"><?= fa_image_tag('star-half-o') . __('Starred projects'); ?></a></li> */ ?>
             <li id="tab_active" class="selected"><a onclick="TBG.Project.loadList('active', '<?= $active_url; ?>');" href="javascript:void(0);"><?= fa_image_tag('diamond') . __('Active projects') . image_tag('spinning_16.gif', ['style' => 'display: none;', 'id' => 'project_list_tab_active_indicator']); ?></a></li>
             <li id="tab_archived" class=""><a onclick="TBG.Project.loadList('archived', '<?= $archived_url; ?>');" href="javascript:void(0);"><?= fa_image_tag('archive') . __('Archived projects') . image_tag('spinning_16.gif', ['style' => 'display: none;', 'id' => 'project_list_tab_archived_indicator']); ?></a></li>
             <?php if ($tbg_user->isAuthenticated()): ?>

--- a/core/modules/main/templates/_projectlist.inc.php
+++ b/core/modules/main/templates/_projectlist.inc.php
@@ -18,9 +18,16 @@
     </div>
 </div>
 <script type="text/javascript">
-    require(['domReady', 'thebuggenie/tbg', 'prototype'], function (domReady, TBG, prototype) {
-        domReady(function () {
-            TBG.Project.loadList('active', '<?= $active_url; ?>');
-        });
-    });
+ require(['domReady', 'thebuggenie/tbg', 'prototype'], function (domReady, TBG, prototype) {
+     domReady(function () {
+         // Default to active tab, unless archived tab was specified
+         // in URL.
+         if (window.location.hash === '#tab_archived') {
+             TBG.Project.loadList('archived', '<?= $archived_url; ?>');
+         }
+         else {
+             TBG.Project.loadList('active', '<?= $active_url; ?>');
+         }
+     });
+ });
 </script>

--- a/public/js/thebuggenie/tbg.js
+++ b/public/js/thebuggenie/tbg.js
@@ -934,7 +934,12 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
                     $(visibletab + '_pane').show();
                 }
                 if (change_hash) {
-                    window.location.hash = visibletab;
+                    if (history.replaceState) {
+                        window.history.replaceState(null, null, '#' + visibletab);
+                    }
+                    else {
+                        window.location.hash = visibletab;
+                    }
                 }
             }
         };


### PR DESCRIPTION
The purpose of this PR is to fix some of the handling around the project tabs (active/archived) on the index page.

The PR takes care of:

- Potential "jumping" on page when click on already selected archived tab.
- Switched to correct tab based on the hash value in browser URL. This way you can create bookmark towards the index page where the archived tab is pre-selected.
- Removes some commented-out code (tiny cleanup).