### PR TITLE
HTTP_X_FORWARDED_PROTO Support

### DIFF
--- a/core/entities/Scope.php
+++ b/core/entities/Scope.php
@@ -289,6 +289,11 @@
             else
             {
                 $hostprefix = (!array_key_exists('HTTPS', $_SERVER) || $_SERVER['HTTPS'] == '' || $_SERVER['HTTPS'] == 'off') ? 'http' : 'https';
+
+                if (array_key_exists('HTTP_X_FORWARDED_PROTO', $_SERVER)) {
+                    $hostprefix = $_SERVER["HTTP_X_FORWARDED_PROTO"];
+                }
+
                 $this->_is_secure = (bool) ($hostprefix == 'https');
                 if(isset($_SERVER["HTTP_X_FORWARDED_HOST"]) && $_SERVER["HTTP_X_FORWARDED_HOST"]!="")
                 {


### PR DESCRIPTION
Allow tbg to be installed behind a proxy with different protocols by respecting [HTTP_X_FORWARDED_PROTO](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto).

Common use case scenario:
- You're using LetsEncrypt
- You want to run certbot in a central place, so that you don't have to hop on many servers every 90 days to renew the certificate
- You're using a proxy (like HAProxy) where it accepts all SSL connections and forwards it to non-https backends

To let backend servers know which protocol the proxy server accepted and for which URL scheme it should generate the URIs, it's common practice to use `X-Forwarded-Proto` which is a de-facto standard.