### PR TITLE
If the user hasn't got access to an issue listed in the timeline or if the issue was deleted, tbg would var_dump() the item.

### DIFF
--- a/core/modules/main/templates/_logitem.inc.php
+++ b/core/modules/main/templates/_logitem.inc.php
@@ -41,7 +41,8 @@
             <?php endif; ?>
         </td>
     </tr>
-<?php elseif ($item->getTargetType() == LogItem::TYPE_ISSUE && $item->getIssue() instanceof Issue && !($item->getIssue()->isDeleted()) && $item->getIssue()->hasAccess()): ?>
+<?php elseif ($item->getTargetType() == LogItem::TYPE_ISSUE && $item->getIssue() instanceof Issue): ?>
+    <?php if ($item->getIssue()->hasAccess() && !($item->getIssue()->isDeleted())): ?>
     <tr>
         <td class="imgtd"<?php if (!isset($include_issue_title) || $include_issue_title): ?> style="padding-top: <?php echo (isset($extra_padding) && $extra_padding) ? 10 : 3; ?>px;"<?php endif; ?>>
             <?php if (!isset($include_issue_title) || $include_issue_title): ?>
@@ -90,6 +91,7 @@
             </div>
         </td>
     </tr>
+    <?php endif; ?>
 <?php else: ?>
     <?php var_dump($item); ?>
 <?php endif; ?>


### PR DESCRIPTION
If the user hasn't got access to an issue listed in the timeline or if the issue was deleted, tbg would var_dump() the item.

This fixes the issue by checking access or deletion one sub-if down.

Not perfect, as the timeline would show now a date header without entries, but better than simply getting a var_dump() if you don't have access ;)
