### PR TITLE
Fix auth_ldap module to follow authentication implementation changes

### DIFF
--- a/core/entities/User.php
+++ b/core/entities/User.php
@@ -527,6 +527,10 @@
                                 $user = $authentication_backend->autoVerifyLogin($request->getCookie('username'), $request->getCookie('elevated_password'), true);
                             }
                         }
+                        // Try autologin if we did not do an auto login using cookies
+                        if(!$request->getCookie('username') && !$user) {
+                            $user = $authentication_backend->doAutoLogin($request);
+                        }
                     }
                     else
                     {

--- a/core/framework/AuthenticationBackend.php
+++ b/core/framework/AuthenticationBackend.php
@@ -72,6 +72,9 @@
         function doLogin($username, $token)
         {
         }
+        function doAutoLogin(Request $request)
+        {
+        }
 
         function logout()
         {

--- a/core/framework/interfaces/AuthenticationProvider.php
+++ b/core/framework/interfaces/AuthenticationProvider.php
@@ -54,6 +54,8 @@
          */
         function doExplicitLogin(Request $request);
 
+        function doAutoLogin(Request $request);
+
         /**
          * @param User $user
          * @param UserSession $token

--- a/modules/auth_ldap/LdapAuthenticationBackend.php
+++ b/modules/auth_ldap/LdapAuthenticationBackend.php
@@ -3,7 +3,7 @@
     namespace thebuggenie\modules\auth_ldap;
 
     use thebuggenie\core\entities\UserSession;
-    use thebuggenie\core\framework\interfaces\AuthenticationProvider;
+    use thebuggenie\core\framework\AuthenticationBackend;
     use thebuggenie\core\entities\Module;
     use thebuggenie\core\entities\User;
     use thebuggenie\core\framework;
@@ -27,7 +27,7 @@
      *
      * @Table(name="\thebuggenie\core\entities\tables\Modules")
      */
-    class LdapAuthenticationBackend implements AuthenticationProvider
+    class LdapAuthenticationBackend extends AuthenticationBackend
     {
 
         /**
@@ -51,11 +51,6 @@
             $this->_module = $module;
         }
 
-        public function getAuthenticationMethod()
-        {
-            return AuthenticationProvider::AUTHENTICATION_TYPE_PASSWORD;
-        }
-
         /**
          * Log-in the user with provided credentials.
          *
@@ -73,49 +68,6 @@
         public function doLogin($username, $password)
         {
             return $this->_loginUser($username, $password, true);
-        }
-
-
-        /**
-         * Verify log-in credentials for previously logged-in user.
-         *
-         * @param string $username
-         *   Username  to log-in with.
-         *
-         * @param string $password
-         *   Password to log-in with.
-         *
-         * @param bool $is_elevated
-         *
-         * @return User|null
-         * @throws \Exception
-         * @retval thebuggenie\core\entities\User | null
-         *   User object associated with the login. If login verification has
-         *   failed, returns null.
-         */
-        public function verifyLogin($username, $password, $is_elevated = false)
-        {
-            return $this->_loginUser($username, $password, false);
-        }
-
-
-        /**
-         * Logs out the user. No module-specific steps are taken for this
-         * module.
-         *
-         */
-        public function logout()
-        {
-            self::getResponse()->deleteCookie('username');
-            self::getResponse()->deleteCookie('password');
-            self::getResponse()->deleteCookie('elevated_password');
-        }
-
-        /**
-         * Token verification (unused)
-         */
-        public function verifyToken($username, $token, $is_elevated = false)
-        {
         }
 
 
@@ -259,35 +211,16 @@
             // Create or update the existing user with up-to-date information.
             list($user, $created) = $this->getModule()->createOrUpdateUser($ldap_user);
 
-            framework\Context::getResponse()->setCookie('username', $username);
-            framework\Context::getResponse()->setCookie('password', $user->getHashPassword());
-
             return $user;
         }
 
-        function autoVerifyLogin($username, $password, $is_elevated = false)
-        {
-            // TODO: Implement autoVerifyLogin() method.
-        }
-
-        function autoVerifyToken($username, $token, $is_elevated = false)
-        {
-            // TODO: Implement autoVerifyToken() method.
-        }
 
         function doExplicitLogin(Request $request)
         {
-            // TODO: Implement doExplicitLogin() method.
-        }
+            $username = $request['username'];
+            $password = $request['password'];
 
-        function persistTokenSession(User $user, UserSession $token, $session_only)
-        {
-            // TODO: Implement persistTokenSession() method.
-        }
-
-        function persistPasswordSession(User $user, $password, $session_only)
-        {
-            // TODO: Implement persistPasswordSession() method.
+            return $this->_loginUser($username, $password, true);
         }
 
 


### PR DESCRIPTION
I made some changes so the ldap authentication works again on >4.1.13 (also see https://forum.thebuggenie.org/d/9-ldap-auth-module )

I did not see a reason why it was using AUTHENTICATION_TYPE_PASSWORD, so I just reused the existing AuthenticationBackend using the TOKEN.

The change to User.php I made so HTTP auth is also working again as it looks to me that implementation got lost also.

It is possible that this is completely not what you want. This is what works for me to have 4.3 up and running. It may be of some use for others.