### PR TITLE
If the user hasn't got access to an issue listed in the timeline or i…

### DIFF
--- a/core/modules/main/templates/_logitem.inc.php
+++ b/core/modules/main/templates/_logitem.inc.php
@@ -21,27 +21,14 @@
             <?php endif; ?>
             <?php if ((!isset($include_issue_title) || $include_issue_title) && (isset($include_user) && $include_user == true)): ?>
                 <br>
-                <span class="user">
-                    <?php if ($item->getUser() instanceof \thebuggenie\core\entities\User): ?>
-                        <?php if ($item->getChangeType() != LogItem::ACTION_COMMENT_CREATED): ?>
-                            <?php echo $item->getUser()->getNameWithUsername().':'; ?>
-                        <?php else: ?>
-                            <?php echo __('%user said', array('%user' => $item->getUser()->getNameWithUsername())).':'; ?>
-                        <?php endif; ?>
-                    <?php else: ?>
-                        <?php if ($item->getChangeType() != LogItem::ACTION_COMMENT_CREATED): ?>
-                            <span class="faded"><?php echo __('Unknown user').':'; ?></span>
-                        <?php else: ?>
-                            <?php echo __('Unknown user said').':'; ?>
-                        <?php endif; ?>
-                    <?php endif; ?>
-                </span>
+                <?php include_component('main/logitemuser', ['item' => $item]); ?>
             <?php elseif (!isset($include_issue_title) || $include_issue_title): ?>
                 <br>
             <?php endif; ?>
         </td>
     </tr>
-<?php elseif ($item->getTargetType() == LogItem::TYPE_ISSUE && $item->getIssue() instanceof Issue && !($item->getIssue()->isDeleted()) && $item->getIssue()->hasAccess()): ?>
+<?php elseif ($item->getTargetType() == LogItem::TYPE_ISSUE && $item->getIssue() instanceof Issue): ?>
+    <?php if ($item->getIssue()->hasAccess() && !($item->getIssue()->isDeleted())): ?>
     <tr>
         <td class="imgtd"<?php if (!isset($include_issue_title) || $include_issue_title): ?> style="padding-top: <?php echo (isset($extra_padding) && $extra_padding) ? 10 : 3; ?>px;"<?php endif; ?>>
             <?php if (!isset($include_issue_title) || $include_issue_title): ?>
@@ -67,21 +54,7 @@
             <?php endif; ?>
             <?php if ((!isset($include_issue_title) || $include_issue_title) && (isset($include_user) && $include_user == true)): ?>
                 <br>
-                <span class="user">
-                    <?php if ($item->getUser() instanceof \thebuggenie\core\entities\User): ?>
-                        <?php if ($item->getChangeType() != LogItem::ACTION_COMMENT_CREATED): ?>
-                            <?php echo $item->getUser()->getNameWithUsername().':'; ?>
-                        <?php else: ?>
-                            <?php echo __('%user said', array('%user' => $item->getUser()->getNameWithUsername())).':'; ?>
-                        <?php endif; ?>
-                    <?php else: ?>
-                        <?php if ($item->getChangeType() != LogItem::ACTION_COMMENT_CREATED): ?>
-                            <span class="faded"><?php echo __('Unknown user').':'; ?></span>
-                        <?php else: ?>
-                            <?php echo __('Unknown user said').':'; ?>
-                        <?php endif; ?>
-                    <?php endif; ?>
-                </span>
+                <?php include_component('main/logitemuser', ['item' => $item]); ?>
             <?php elseif (!isset($include_issue_title) || $include_issue_title): ?>
                 <br>
             <?php endif; ?>
@@ -90,6 +63,36 @@
             </div>
         </td>
     </tr>
+    <?php endif; ?>
 <?php else: ?>
-    <?php var_dump($item); ?>
+    <tr>
+        <td class="imgtd"<?php if (!isset($include_issue_title) || $include_issue_title): ?> style="padding-top: <?php echo (isset($extra_padding) && $extra_padding) ? 10 : 3; ?>px;"<?php endif; ?>>
+            <?php if (!isset($include_issue_title) || $include_issue_title): ?>
+                <?php echo fa_image_tag('question', ['class' => 'issuetype-icon issuetype-unknown', 'title' => __('Unknown log item type')]); ?>
+            <?php endif; ?>
+        </td>
+        <td style="clear: both;<?php if (!isset($include_issue_title) || $include_issue_title): ?> padding-bottom: <?php echo (isset($extra_padding) && $extra_padding) ? 15 : 10; ?>px;<?php endif; ?>">
+            <?php if ((!isset($include_issue_title) || $include_issue_title) && (isset($include_time) && $include_time == true)): ?><span class="time"><?php echo tbg_formatTime($item->getTime(), 19); ?></span>&nbsp;<?php endif; ?>
+            <?php if (!isset($include_issue_title) || $include_issue_title): ?>
+                <?php if (isset($include_project) && $include_project == true): ?><span class="faded_out smaller"><?php echo image_tag($item->getProject()->getSmallIconName(), array('class' => 'issuelog-project-logo'), $item->getProject()->hasSmallIcon()); ?></span><?php endif; ?>
+            <?php endif; ?>
+            <?php
+                $title = "[".__('Unknown log item type')."]";
+            ?>
+            <?php if (!isset($include_issue_title) || $include_issue_title): ?>
+                <span style="margin-top: 7px;">
+                    <?php echo $title; ?>
+                </span>
+            <?php endif; ?>
+            <?php if ((!isset($include_issue_title) || $include_issue_title) && (isset($include_user) && $include_user == true)): ?>
+                <br>
+                <?php include_component('main/logitemuser', ['item' => $item]); ?>
+            <?php elseif (!isset($include_issue_title) || $include_issue_title): ?>
+                <br>
+            <?php endif; ?>
+            <div class="log-item <?php if (!isset($include_issue_title) || $include_issue_title == false) echo 'without-title'; ?>">
+                <?php include_component('main/logitemtext', ['item' => $item]); ?>
+            </div>
+        </td>
+    </tr>
 <?php endif; ?>

--- a/core/modules/main/templates/_logitemuser.inc.php
+++ b/core/modules/main/templates/_logitemuser.inc.php
@@ -1,0 +1,22 @@
+<?php
+
+    use thebuggenie\core\entities\LogItem;
+
+    /** @var LogItem $item */
+
+?>
+                <span class="user">
+                    <?php if ($item->getUser() instanceof \thebuggenie\core\entities\User): ?>
+                        <?php if ($item->getChangeType() != LogItem::ACTION_COMMENT_CREATED): ?>
+                            <?php echo $item->getUser()->getNameWithUsername().':'; ?>
+                        <?php else: ?>
+                            <?php echo __('%user said', array('%user' => $item->getUser()->getNameWithUsername())).':'; ?>
+                        <?php endif; ?>
+                    <?php else: ?>
+                        <?php if ($item->getChangeType() != LogItem::ACTION_COMMENT_CREATED): ?>
+                            <span class="faded"><?php echo __('Unknown user').':'; ?></span>
+                        <?php else: ?>
+                            <?php echo __('Unknown user said').':'; ?>
+                        <?php endif; ?>
+                    <?php endif; ?>
+                </span>


### PR DESCRIPTION
…f the issue was deleted, tbg would var_dump() the item.

Based on the PR #539 of @Drachenkaetzchen, taking into account the comment of @zegenie. (Created a new as I don't know what the behavior would be if I try to add something to that one)
This prints the most possible information of an unknown LogItem.

Remarks of @Drachenkaetzchen still hold:
> Not perfect, as the timeline would show now a date header without entries, but better than simply getting a var_dump() if you don't have access ;)

How to fix this?
* Getting the output in an output buffer and checking if there is some output for a date before echoing the output
* or running over the logitems and doing the same checks
* or something else?

For now, I think this is enough