### PR TITLE
Fix for two notification emails for new comments and none for edited comments

### DIFF
--- a/core/entities/Comment.php
+++ b/core/entities/Comment.php
@@ -406,7 +406,9 @@
                     }
                     $this->_addTargetNotifications();
                 }
-
+            }
+            else
+            {
                 switch ($this->getTargetType())
                 {
                     case self::TYPE_ISSUE:


### PR DESCRIPTION
Notification emails for comments are:
* for new comments: sent twice
* for edited comments: not sent

In commit 7dc7251d105ef65f6805f4a872ab222892ad0d14, there is an "else" removed. Putting this back solves both problems as
* the notifications for new comments are already handled in core/modules/main/controllers/Main.php by the means of the Comment::createNew event.
* the Comment::_postSave event should (also) be called when a non-new comment is saved