### PR TITLE
Fix notifications not shown on new issue

### DIFF
--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -5590,9 +5590,17 @@
             {
                 if ($this->shouldAutomaticallySubscribeUser($user)) $this->addSubscriber($user->getID());
 
-                if ($this->getCategory() instanceof Category && $user->getNotificationSetting(framework\Settings::SETTINGS_USER_NOTIFY_NEW_ISSUES_MY_PROJECTS_CATEGORY . '_' . $this->getCategory()->getID(), false)->isOn())
+                if ($this->shouldAddNotification($user))
                     $this->_addNotificationIfNotNotified(Notification::TYPE_ISSUE_CREATED, $user, $updated_by);
             }
+        }
+
+        protected function shouldAddNotification($related_user)
+        {
+            if ($this->getCategory() instanceof Category && $related_user->getNotificationSetting(framework\Settings::SETTINGS_USER_NOTIFY_NEW_ISSUES_MY_PROJECTS_CATEGORY . '_' . $this->getCategory()->getID(), false)->isOn())
+                return true;
+
+            return $related_user->getNotificationSetting(framework\Settings::SETTINGS_USER_NOTIFY_NEW_ISSUES_MY_PROJECTS, false)->isOn();
         }
 
         public function triggerSaveEvent($comment, $updated_by)


### PR DESCRIPTION
No notifications was given to the user when no category is selected in the notification settings (or no category is given to the issue on creation).
Fixed by checking the same way as shouldAutomaticallySubscribeUser