### PR TITLE
Do not sanitize (htmlentities) username and password for LDAP login

### DIFF
--- a/modules/auth_ldap/LdapAuthenticationBackend.php
+++ b/modules/auth_ldap/LdapAuthenticationBackend.php
@@ -217,8 +217,8 @@
 
         function doExplicitLogin(Request $request)
         {
-            $username = $request['username'];
-            $password = $request['password'];
+            $username = $request->getRawParameter('username');
+            $password = $request->getRawParameter('password');
 
             return $this->_loginUser($username, $password, true);
         }


### PR DESCRIPTION
Passwords with html special characters in did not work as they got replaced by the corresponding html entity.

Maybe this problem occurs also on other places, but this fix has the least (possible) side-effects.