### PR TITLE
Fix automatic subscription for selected projects.

### DIFF
--- a/core/entities/Issue.php
+++ b/core/entities/Issue.php
@@ -5636,7 +5636,7 @@
                     return true;
             }
 
-            return ($user->getNotificationSetting(framework\Settings::SETTINGS_USER_SUBSCRIBE_NEW_ISSUES_MY_PROJECTS, false)->isOn() || $user->getNotificationSetting(framework\Settings::SETTINGS_USER_SUBSCRIBE_NEW_ISSUES_MY_PROJECTS . '_' . $this->getProject()->getId(), false)->isOn());
+            return ($user->getNotificationSetting(framework\Settings::SETTINGS_USER_SUBSCRIBE_NEW_ISSUES_MY_PROJECTS, false)->isOn() || $user->getNotificationSetting(framework\Settings::SETTINGS_USER_SUBSCRIBE_NEW_ISSUES_MY_PROJECTS . '_' . $this->getProject()->getKey(), false)->isOn());
         }
 
         protected function _postSave($is_new)


### PR DESCRIPTION
This basically reverts commit d56a8d7a9de10d3661313e9215a44307471a682d - I added a comment there:

In core/modules/main/controllers/Main.php and core/modules/main/templates/myaccount.html.php, the key is used. The configuration in the database uses the key.
So, in version 4.3.1, the automatic subscription does not work.

The parameter used in the code is named $project_**id**, but the value is taken from the **key** in Project::getAll() and $projects; resulting from Projects::KEY = 'projects.key'). Being the value of the column Projects::KEY = 'projects.key'.
I don't see a reason why this should be id as stated in the commit message.