### PR TITLE
Fix TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 php:
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:
@@ -16,6 +17,6 @@ env:
   - DB=pgsql
 
 before_script:
-  - composer update
+  - composer update --ignore-platform-reqs
 
 script: vendor/phpunit/phpunit/phpunit --coverage-text tests/


### PR DESCRIPTION
- Added PHP 7.3
- Added `--ignore-platform-reqs` composer option to `composer update` to bypass composer checks for PHP extensions (required to run a TBG instance but not to run `phpunit` tests).