### PR TITLE
Require issue add permission for adding epics

### DIFF
--- a/modules/agile/controllers/Main.php
+++ b/modules/agile/controllers/Main.php
@@ -527,6 +527,13 @@
         public function runAddEpic(framework\Request $request)
         {
             $this->forward403unless($this->_checkProjectPageAccess('project_planning'));
+            
+            // Since this creates an issue, user should also have permission to create an issue
+            $this->forward403unless(
+            	framework\Context::getCurrentProject() instanceof \thebuggenie\core\entities\Project && 
+            	framework\Context::getCurrentProject()->hasAccess() && 
+            	$this->getUser()->canReportIssues(framework\Context::getCurrentProject()));
+            
             $board = entities\tables\AgileBoards::getTable()->selectById($request['board_id']);
 
             try


### PR DESCRIPTION
Since adding an epic adds an issue to the board, it seems that the user should need to have permission to add an issue if they want to add an epic.  Right now it only requires permission to view the board.  A user might have view permission but not issue add permission, such as the case of a guest user.

This copies the issue add permission check (from runReportIssue()) into the add epic function in the agile module.

Note that it currently doesn't display an error message, it just silently fails (this would be a good improvement in future).