### PR TITLE
Require higher level permissions for agile changes

### DIFF
--- a/modules/agile/controllers/Main.php
+++ b/modules/agile/controllers/Main.php
@@ -124,12 +124,24 @@
 
             if ($request->isDelete())
             {
+            	// Check for scrum permission to modify boards
+            	if (!$this->_checkProjectPageAccess('project_scrum'))
+            	{
+            		throw new \Exception($this->getI18n()->__("You don't have access to modify boards (scrum permission)"));
+            	}
+            	
                 $board_id = $this->board->getID();
                 $this->board->delete();
                 return $this->renderJSON(array('message' => $this->getI18n()->__('The board has been deleted'), 'board_id' => $board_id));
             }
             elseif ($request->isPost())
             {
+            	// Check for scrum permission to modify boards
+            	if (!$this->_checkProjectPageAccess('project_scrum'))
+            	{
+            		throw new \Exception($this->getI18n()->__("You don't have access to modify boards (scrum permission)"));
+            	}
+            	
                 $this->board->setName($request['name']);
                 $this->board->setDescription($request['description']);
                 $this->board->setType($request['type']);
@@ -339,6 +351,12 @@
             {
                 if ($request->isPost())
                 {
+                	// Check for scrum permission to modify boards
+                	if (!$this->_checkProjectPageAccess('project_scrum'))
+                	{
+                		throw new \Exception($this->getI18n()->__("You don't have access to modify boards (scrum permission)"));
+                	}
+                	
                     $columns = $request['columns'];
                     $saved_columns = array();
                     $cc = 1;


### PR DESCRIPTION
Currently, several operations that permit viewing agile boards also allow them to be modified.

It would be nice for operations that change agile boards to be restricted to users with a higher permission set.  IE, it would be useful to be able to show agile boards to guest users, without also allowing guest users to modify them.

This change expands the existing 'project_scrum' permission, which was previously only used to gate assigning milestones, to also gate several other modification checks.  (It seemed like this was intended to be like a scrum master type permission (?))

Note that it currently doesn't display an error message, or hide the edit buttons -- it just silently fails (this would be a good improvement in future).