### PR TITLE
Fix for Custom Access Policy add panel never displaying

### DIFF
--- a/core/modules/main/templates/_issuepermissions.inc.php
+++ b/core/modules/main/templates/_issuepermissions.inc.php
@@ -10,7 +10,7 @@
         <?php image_tag('spinning_16.gif', array('id' => 'acl_indicator_'.$issue->getID(), 'style' => '')); ?>
         <div id="acl-users-teams-selector" style="<?php if($issue->isUnlocked() && $issue->isUnlockedCategory()): ?> display: none;<?php endif; ?>">
             <h4 style="margin-top: 10px;">
-                <?php echo javascript_link_tag(__('Add a user or team'), array('onclick' => "$('popup_find_acl_{$issue->getID()}').toggle('block');", 'style' => 'float: right;', 'class' => 'button button-silver')); ?>
+                <?php echo javascript_link_tag(__('Add a user or team'), array('onclick' => "var tempPopup = $('popup_find_acl_{$issue->getID()}');  if (tempPopup.style.opacity == 0) { tempPopup.toggle('block'); tempPopup.style.opacity = 1.0; tempPopup.style.transform = 'none'; tempPopup.style.display = 'block';} else { tempPopup.toggle('block'); }", 'style' => 'float: right;', 'class' => 'button button-silver')); ?>
                 <?php echo __('Users or teams who can see this issue'); ?>
             </h4>
             <?php include_component('main/identifiableselector', array(    'html_id'             => "popup_find_acl_{$issue->getID()}",

--- a/core/modules/main/templates/_reportissue.inc.php
+++ b/core/modules/main/templates/_reportissue.inc.php
@@ -789,7 +789,7 @@
                         <?php image_tag('spinning_16.gif', array('id' => 'acl_indicator_', 'style' => '')); ?>
                         <div id="acl-users-teams-selector" style="display: none;">
                             <h4 style="margin-top: 10px;">
-                                <?= javascript_link_tag(__('Add a user or team'), array('onclick' => "$('popup_find_acl_').toggle('block');", 'style' => 'float: right;', 'class' => 'button button-silver')); ?>
+                                <?= javascript_link_tag(__('Add a user or team'), array('onclick' => "var tempPopup = $('popup_find_acl_');  if (tempPopup.style.opacity == 0) { tempPopup.toggle('block'); tempPopup.style.opacity = 1.0; tempPopup.style.transform = 'none'; tempPopup.style.display = 'block';} else { tempPopup.toggle('block'); }", 'style' => 'float: right;', 'class' => 'button button-silver')); ?>
                                 <?= __('Users or teams who can see this issue'); ?>
                             </h4>
                             <?php include_component('main/identifiableselector', array(    'html_id'             => "popup_find_acl_",


### PR DESCRIPTION
When creating or editing an issue, clicking 'Add a user or team' would never display the dropdown to add a user or team.  This change allows it to toggle that panel.