### PR TITLE
Don't auto log out if already logged out

### DIFF
--- a/core/framework/AuthenticationBackend.php
+++ b/core/framework/AuthenticationBackend.php
@@ -46,6 +46,9 @@
          */
         function autoVerifyToken($username, $token, $is_elevated = false)
         {
+            if (empty($username) || empty($token)) // not claiming to be a user, no one to auth against. 
+                return null;
+            
             $user = Users::getTable()->getByUsername($username);
 
             if (!$user instanceof User)


### PR DESCRIPTION
TBG logs out the user anytime they're not already logged in.  While theoretically that shouldn't be an issue, it was causing two different problems for me, one in my prod environment (LAMP), and one in my test environment (WAMP).

1) On WAMP server, throwing an error during session_regenerate_id since it was attempting to delete a session that hadn't yet been created.
2) On LAMP server, was unable to generate captcha images since the session was being tossed out.