### PR TITLE
Use livelink parametername to get branch in vcs_integration, fix "All branches"

### DIFF
--- a/modules/vcs_integration/controllers/Main.php
+++ b/modules/vcs_integration/controllers/Main.php
@@ -57,7 +57,7 @@
             if ($request->isPost())
             {
                 $offset = $request->getParameter('offset', 0);
-                $this->commits = Commit::getByProject($this->selected_project->getID(), 40, $offset, $request->getParameter('branchname'), $request->getParameter('gitlab_repos_nss'));
+                $this->commits = Commit::getByProject($this->selected_project->getID(), 40, $offset, $request->getParameter('branch'), $request->getParameter('gitlab_repos_nss'));
 
                 return $this->renderJSON(array('content' => $this->getComponentHTML('vcs_integration/projectcommitsbox', array('commits' => $this->commits, 'selected_project' => $this->selected_project, 'branchname' => $request->getParameter('branchname'), 'gitlab_repos_nss' => $request->getParameter('gitlab_repos_nss'))), 'offset' => $offset + 40));
             }
@@ -112,7 +112,7 @@
             }
 
             $offset = $request->getParameter('offset', 0);
-            $this->commits = Commit::getByProject($this->selected_project->getID(), 40, $offset, $request->getParameter('branchname'), $request->getParameter('gitlab_repos_nss'));
+            $this->commits = Commit::getByProject($this->selected_project->getID(), 40, $offset, $request->getParameter('branch'), $request->getParameter('gitlab_repos_nss'));
 
             return $this->renderJSON(array('content' => $this->getComponentHTML('vcs_integration/projectcommits', array('commits' => $this->commits, 'selected_project' => $this->selected_project)), 'offset' => $offset + 40));
         }

--- a/public/js/thebuggenie/tbg.js
+++ b/public/js/thebuggenie/tbg.js
@@ -2128,9 +2128,8 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
         TBG.Project.showBranchCommits = function (url, branch) {
             $$('body')[0].setStyle({'overflow': 'auto'});
 
-            TBG.Main.Helpers.ajax(url, {
+            var parameters = {
                 url_method: 'post',
-                additional_params: "branch=" + branch,
                 loading: {
                     indicator: 'fullpage_backdrop',
                     show: 'fullpage_backdrop_indicator',
@@ -2140,7 +2139,11 @@ define(['prototype', 'effects', 'controls', 'scriptaculous', 'jquery', 'TweenMax
                     show: 'project_commits_box',
                     update: 'project_commits'
                 }
-            });
+            };
+            if(branch !== undefined) {
+                parameters['additional_params'] = "branch=" + branch;
+            }
+            TBG.Main.Helpers.ajax(url, parameters);
         }
 
         TBG.Project.Commits.update = function (url, branch) {


### PR DESCRIPTION
Selecting branches in vcs_integration:commits did not work as the parameter name was change in javascript for livelink.

Selecting "All branches" gives "undefined" to php. I suppose this also fixes "All branches" in livelink.