### PR TITLE
Allow use of PHP packages built against lib-pcre 8.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "realityking/pchart": "dev-master",
         "phpoffice/phpexcel": "~1.8",
         "kriswallsmith/assetic": "~1.2",
-        "lib-pcre" : "8.*",
+        "lib-pcre" : ">=8.0",
         "net/http" : "^1.1",
         "guzzlehttp/guzzle": "^6.3",
         "scrivo/highlight.php": "^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -2590,7 +2590,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1|^7.2",
-        "lib-pcre": "8.*",
+        "lib-pcre": ">=8.0",
         "ext-apc": "*",
         "ext-gd": "*",
         "ext-curl": "*",


### PR DESCRIPTION
- Instead of depending on PHP packages built specifically against the
  version 8.x of lib-pcre, allow use of PHP packages built against
  more recent library version as well. At the very least lib-pcre 10.x
  works perfectly fine.
- Fixes issue #2878.