### PR TITLE
Update development environment set-up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
 
   # Configure a single virtual machine.
   config.vm.box = "debian/contrib-buster64"
-  config.vm.hostname = "tbg"
+  config.vm.hostname = "tbg-dev"
 
   # Forward ports for accessing the web server.
   config.vm.network "forwarded_port", guest: 80, host: 8080

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,13 @@
 
 Vagrant.configure("2") do |config|
 
+  # Increase default allocated memory for the virtual machines.
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 1024
+  end
+
   # Configure a single virtual machine.
-  config.vm.box = "bento/debian-9.4"
+  config.vm.box = "debian/contrib-buster64"
   config.vm.hostname = "tbg"
 
   # Forward ports for accessing the web server.
@@ -20,6 +25,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "ansible_local" do |ansible|
     ansible.playbook = "ansible/provision.yml"
     ansible.install_mode = "pip"
-    ansible.version = "2.5.4"
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python"
+    ansible.version = "2.9.16"
   end
 end

--- a/ansible/files/mutex.conf
+++ b/ansible/files/mutex.conf
@@ -1,0 +1,3 @@
+# If not set, httpd has a tendency to crash during startup with:
+# [mpm_prefork:emerg] [pid 811] (43)Identifier removed: AH00144: couldn't grab the accept mutex
+Mutex file:${APACHE_LOCK_DIR} default

--- a/ansible/files/servername.conf
+++ b/ansible/files/servername.conf
@@ -1,0 +1,1 @@
+ServerName tbg

--- a/ansible/files/servername.conf
+++ b/ansible/files/servername.conf
@@ -1,1 +1,1 @@
-ServerName tbg
+ServerName tbg-dev

--- a/ansible/files/vhost.conf
+++ b/ansible/files/vhost.conf
@@ -10,8 +10,6 @@
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot /vagrant/public
-	RMode          config
-	RUidGid        vagrant vagrant
 
 	<Directory /vagrant/public>
 	        Options FollowSymlinks
@@ -48,8 +46,6 @@
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot /vagrant/public
-	RMode          config
-	RUidGid        vagrant vagrant
 
 	<Directory /vagrant/public>
 	        Options FollowSymlinks

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -4,6 +4,11 @@
   become: yes
   tasks:
 
+
+    ########################
+    # Package installation #
+    ########################
+
     - name: Set configuration options for Debian packages
       debconf:
         name: "{{ item.package }}"
@@ -18,35 +23,41 @@
 
     - name: Install MariaDB, Apache httpd with PHP support, and OpenLDAP server
       apt:
-        name: "{{ item }}"
+        name:
+          # Database server.
+          - mariadb-server
+          - mariadb-client
+          - python-mysqldb
+          # Apache + PHP base requirements.
+          - apache2
+          - libapache2-mod-php
+          - php-apcu
+          - php-curl
+          - php-gd
+          - php-ldap
+          - php-mbstring
+          - php-mysql
+          - php-xml
+          - php-zip
+          # Composer dependencies.
+          - unzip
+          # HTTPS/TLS.
+          - gnutls-bin
+          # Developer tools.
+          - php-xdebug
+          # LDAP server.
+          - slapd
+          - ldap-utils
+          - python-ldap
+          - php-ldap
         state: present
-      with_items:
-        # Database server.
-        - mariadb-server
-        - mariadb-client
-        - python-mysqldb
-        # Apache + PHP base requirements.
-        - apache2
-        - libapache2-mod-php7.0
-        - libapache2-mod-ruid2
-        - php-gd
-        - php-curl
-        - php-mysql
-        - php-mbstring
-        - php-xml
-        # Composer dependencies.
-        - unzip
-        # HTTPS/TLS.
-        - gnutls-bin
-        # Developer tools.
-        - php-xdebug
-        # LDAP server.
-        - slapd
-        - ldap-utils
-        - python-ldap
-        - php-ldap
       notify:
         - Restart apache2
+
+
+    ################################
+    # X.509 certificate generation #
+    ################################
 
     - name: Create directories for storing artefacts
       file:
@@ -105,7 +116,7 @@
       command: /usr/sbin/update-ca-certificates
       when: ca_certificate_deployed.changed
 
-    - name: Issue Apache2 server certificate
+    - name: Issue Apache httpd server certificate
       command: certtool --generate-certificate
                --load-ca-privkey "/vagrant/artefacts/x509/ca.key.pem" --load-ca-certificate "/vagrant/artefacts/x509/ca.cert.pem"
                --template "/vagrant/artefacts/x509/apache2.cfg"
@@ -114,6 +125,11 @@
       args:
         creates: "/vagrant/artefacts/x509/apache2.cert.pem"
       become_user: vagrant
+
+
+    #############################
+    # LDAP server configuration #
+    #############################
 
     - name: Issue slapd server certificate
       command: certtool --generate-certificate
@@ -130,7 +146,7 @@
         path: /etc/ssl/private/
         mode: o+x
 
-    - name: Deploy private key for Apache2
+    - name: Deploy private key for Apache httpd
       copy:
         src: /vagrant/artefacts/x509/apache2.key.pem
         dest: /etc/ssl/private/apache2.key.pem
@@ -140,7 +156,7 @@
       notify:
         - Restart apache2
 
-    - name: Deploy certificate for Apache2
+    - name: Deploy certificate for Apache httpd
       copy:
         src: /vagrant/artefacts/x509/apache2.cert.pem
         dest: /etc/ssl/certs/apache2.cert.pem
@@ -401,6 +417,11 @@
             cn: groupnoaccess2
             member: uid=usernoaccess,ou=people,dc=tbg,dc=local
 
+
+    ##############################
+    # Apache httpd configuration #
+    ##############################
+
     - name: Enable mod_ssl
       apache2_module:
         name: ssl
@@ -423,18 +444,53 @@
         group: root
         mode: 0644
       with_items:
-        - /etc/php/7.0/apache2/conf.d/99-local.ini
-        - /etc/php/7.0/cli/conf.d/99-local.ini
+        - /etc/php/7.3/apache2/conf.d/99-local.ini
+        - /etc/php/7.3/cli/conf.d/99-local.ini
       notify:
         - Restart apache2
 
-    - name: Replace Apache default virtual host configuration
+    - name: Replace default virtual host configuration
       copy:
         src: vhost.conf
-        dest: /etc/apache2/sites-available/000-default.conf
+        dest: /etc/apache2/conf-enabled/
         owner: root
         group: root
         mode: 0644
+      notify:
+        - Restart apache2
+
+    - name: Configure default server name
+      copy:
+        src: servername.conf
+        dest: /etc/apache2/conf-enabled/servername.conf
+        owner: root
+        group: root
+        mode: 0644
+      notify:
+        - Restart apache2
+
+    - name: Configure mutex file location
+      copy:
+        src: mutex.conf
+        dest: /etc/apache2/conf-enabled/mutex.conf
+        owner: root
+        group: root
+        mode: 0644
+      notify:
+        - Restart apache2
+
+    - name: Run httpd as user vagrant
+      lineinfile:
+        path: /etc/apache2/envvars
+        regexp: "^export APACHE_RUN_USER=www-data"
+        line: "export APACHE_RUN_USER=vagrant"
+        state: present
+      notify:
+        - Restart apache2
+
+    #################################
+    # Database server configuration #
+    #################################
 
     - name: Create database
       mysql_db:
@@ -451,10 +507,15 @@
         priv: 'tbg.*:ALL'
         state: present
 
+
+    ###############################
+    # The Bug Genie configuration #
+    ###############################
+
     - name: Download composer
       get_url:
-        url: https://getcomposer.org/download/1.3.0/composer.phar
-        checksum: sha256:92ce3125cae2015c5c1f7657e78a6e239ff47b714eb1418288abf45d55f3be27
+        url: https://getcomposer.org/download/1.10.19/composer.phar
+        checksum: sha256:688bf8f868643b420dded326614fcdf969572ac8ad7fbbb92c28a631157d39e8
         dest: /usr/local/bin/composer
         owner: vagrant
         group: vagrant

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -318,7 +318,7 @@
             givenName: Admin
             sn: Adminsky
             cn: Admin Adminsky
-            mail: administrator@tbg.local
+            mail: administrator@tbg-dev.local
 
         - dn: uid=user1,ou=people,dc=tbg,dc=local
           objectClass: inetOrgPerson
@@ -328,7 +328,7 @@
             givenName: First
             sn: User
             cn: First User
-            mail: user1@tbg.local
+            mail: user1@tbg-dev.local
 
         - dn: uid=user2,ou=people,dc=tbg,dc=local
           objectClass: inetOrgPerson
@@ -338,7 +338,7 @@
             givenName: Second
             sn: User
             cn: Second User
-            mail: user2@tbg.local
+            mail: user2@tbg-dev.local
 
         - dn: uid=user3,ou=people,dc=tbg,dc=local
           objectClass: inetOrgPerson
@@ -348,7 +348,7 @@
             givenName: Third
             sn: User
             cn: Third User
-            mail: user3@tbg.local
+            mail: user3@tbg-dev.local
 
         - dn: uid=user4,ou=people,dc=tbg,dc=local
           objectClass: inetOrgPerson
@@ -358,7 +358,7 @@
             givenName: Fourth
             sn: User
             cn: Fourth User
-            mail: user4@tbg.local
+            mail: user4@tbg-dev.local
 
         - dn: uid=user5,ou=people,dc=tbg,dc=local
           objectClass: inetOrgPerson
@@ -368,7 +368,7 @@
             givenName: Fifth
             sn: User
             cn: Fifth User
-            mail: user5@tbg.local
+            mail: user5@tbg-dev.local
 
         - dn: uid=usernoaccess,ou=people,dc=tbg,dc=local
           objectClass: inetOrgPerson
@@ -378,7 +378,7 @@
             givenName: Ignored
             sn: User
             cn: Ignored User
-            mail: usernoaccess@tbg.local
+            mail: usernoaccess@tbg-dev.local
 
         # Groups.
         - dn: cn=tbg1,ou=groups,dc=tbg,dc=local
@@ -487,6 +487,7 @@
         state: present
       notify:
         - Restart apache2
+
 
     #################################
     # Database server configuration #

--- a/ansible/templates/x509/apache2.cfg.j2
+++ b/ansible/templates/x509/apache2.cfg.j2
@@ -15,8 +15,8 @@ expiration_days = 365
 
 # IP address of web server.
 dns_name = "localhost"
-dns_name = "tbg"
-dns_name = "tbg.local"
+dns_name = "tbg-dev"
+dns_name = "tbg-dev.local"
 ip_address = "127.0.0.1"
 ip_address = "{{ ansible_default_ipv4.address }}"
 

--- a/ansible/templates/x509/slapd.cfg.j2
+++ b/ansible/templates/x509/slapd.cfg.j2
@@ -6,7 +6,7 @@
 organization = "The Bug Genie Development Environment"
 
 # The common name of the certificate owner.
-cn = "The Bug Genie Development LDPA Server"
+cn = "The Bug Genie Development LDAP Server"
 
 # In how many days, counting from today, this certificate will expire.
 expiration_days = 365
@@ -15,8 +15,8 @@ expiration_days = 365
 
 # DNS and IP addresses for the server.
 dns_name = "localhost"
-dns_name = "tbg"
-dns_name = "tbg.local"
+dns_name = "tbg-dev"
+dns_name = "tbg-dev.local"
 ip_address = "127.0.0.1"
 ip_address = "{{ ansible_default_ipv4.address }}"
 


### PR DESCRIPTION
- Switch to using Debian 10 Buster (comes with PHP 7.3). Use
  "official" Debian project images instead of the bento ones.
- Upgrade to using Ansible 2.9.x.
- Drop the use of mod_ruid2, since it is unmaintained, and has been
  dropped from Debian 10 Buster.
- Update list of installed packages, and reorganise them slightly.
- Add comment sections to the provisioning playbook for better task
  grouping/separation.
- Switch to running the web server as user vagrant (substitute for
  mod_ruid2).
- Upgrade composer to latest 1.10.x release. Although 2.x has come out
  as well, the 1.10.x works slightly better with Ansible 2.9.x.
- Small updates to the names of tasks (call it Apache httpd instead of
  Apache2 in a couple of places.
- Configure Apache httpd default server name in order to supress
  annoying warnings in the log.
- Increase amount of memory allocated to Vagrant virtual machine to
  avoid swapping and performance issues.
- Deploy mutex file location configuration file in development
  environment to avoid httpd crashes during machine start-up
  (Identifier removed: AH00144: couldn't grab the accept mutex).