### PR TITLE
Removed default value for date parameter

### DIFF
--- a/modules/vcs_integration/Vcs_integration.php
+++ b/modules/vcs_integration/Vcs_integration.php
@@ -273,7 +273,7 @@
             include_component('vcs_integration/viewissue_commits', array('issue' => $event->getSubject(), 'links' => $links, 'links_total_count' => $links_total_count, 'selected_project' => $event->getSubject()->getProject()));
         }
 
-        public static function processCommit(\thebuggenie\core\entities\Project $project, $commit_msg, $old_rev, $new_rev, $date = null, $changed, $author, $branch = null, \Closure $callback = null)
+        public static function processCommit(\thebuggenie\core\entities\Project $project, $commit_msg, $old_rev, $new_rev, $date, $changed, $author, $branch = null, \Closure $callback = null)
         {
             $output = '';
             framework\Context::setCurrentProject($project);


### PR DESCRIPTION
Removed default null value for date parameter in processCommit. Will be forbidden in PHP 8 and was never used anyway.